### PR TITLE
fix: getting started steps and build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This repository contains the source code for the [AWS Amplify Discord Server](ht
 
 1. `gh repo fork aws-amplify/discord-bot`
 2. `pnpm install`
-3. `pnpm build`
-4. Rename `.env.sample` to `.env.local` and [add necessary Discord environment values](#setting-up-a-discord-bot)
+3. Rename `.env.sample` to `.env.local` and [add necessary Discord environment values](#setting-up-a-discord-bot)
+4. `pnpm build`
 5. Run the bot with `pnpm bot dev`
 6. Navigate to `http://localhost:3000/admin` and sync the commands
 7. Refresh your Discord client and try out a command!

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "bot": "pnpm --filter @hey-amplify/bot",
     "apps": "pnpm --filter \"./apps/**\"",
-    "build": "pnpm -r run build",
+    "packages": "pnpm --filter \"./packages/**\"",
+    "build": "pnpm packages run build && pnpm apps run build",
     "dev": "pnpm -r run build -w",
     "test": "pnpm --filter ./e2e run e2e"
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- re-adds `packages` script
- modifies build to run `packages` build before `apps`
- re-orders getting-started steps to mitigate "DATABASE_URL env var not found" issue with app build


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
