### PR TITLE
fix: load DATABASE_URL with SvelteKit

### DIFF
--- a/apps/bot/svelte.config.js
+++ b/apps/bot/svelte.config.js
@@ -13,6 +13,7 @@ Object.assign(
   loadEnv('development', new URL('../../', import.meta.url).pathname, [
     'DISCORD_',
     'GITHUB_',
+    'DATABASE_',
   ])
 )
 
@@ -61,7 +62,6 @@ const config = {
         },
       },
       rollupOptions: {
-        input: 'src/server.ts',
         external: Object.keys(pkg.dependencies),
         output: {
           inlineDynamicImports: false,

--- a/apps/bot/svelte.config.js
+++ b/apps/bot/svelte.config.js
@@ -7,15 +7,22 @@ import { loadEnv } from 'vite'
 // https://nodejs.org/api/esm.html#esm_no_json_module_loading
 const pkg = JSON.parse(await readFile(resolve('package.json'), 'utf-8'))
 
-// load env vars for development
-Object.assign(
-  process.env,
-  loadEnv('development', new URL('../../', import.meta.url).pathname, [
-    'DISCORD_',
-    'GITHUB_',
-    'DATABASE_',
-  ])
-)
+/**
+ * Load's environment variables for development
+ * by default Vite's `loadEnv` will only load variables prefixed with "VITE_"
+ */
+function loadEnvVars() {
+  Object.assign(
+    process.env,
+    loadEnv('development', new URL('../../', import.meta.url).pathname, [
+      'DISCORD_',
+      'GITHUB_',
+      'DATABASE_',
+    ])
+  )
+}
+
+loadEnvVars()
 
 function relative(path) {
   return new URL(path, import.meta.url).pathname


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- moves loadEnvVars into its own function for documentation purposes
- load variables prefixed with `DATABASE_` (fixes prisma issue)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.