### PR TITLE
fix: docker build env vars for Svelte-Kit (import.meta.env)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,9 +14,7 @@ DATABASE_URL="file:../db/local.db"
 # secrets for next-auth
 # https://next-auth.js.org/configuration/options#environment-variables
 NEXTAUTH_SECRET=nextauthsecret # CHANGE ME
-NEXTAUTH_URL=http://localhost:3000
 
 # expose to Vite (Svelte-Kit)
 VITE_HOST=http://localhost:3000
-VITE_NEXTAUTH_URL=$NEXTAUTH_URL
-VITE_NEXTAUTH_SECRET=$NEXTAUTH_SECRET
+VITE_NEXTAUTH_URL=$VITE_HOST

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN pnpm run build:lib && pnpm run build
 RUN pnpm install --offline --frozen-lockfile --prod --ignore-scripts
 
 # expose necessary env vars
-ENV DISCORD_BOT_TOKEN=""
 ENV PORT=3000
 ENV DATABASE_URL="file:../db/data.db"
 

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -13,6 +13,7 @@
     "constructs": "^10.0.123",
     "source-map-support": "^0.5.21",
     "typescript": "^4.6.3",
+    "vite": "^2.9.12",
     "vite-node": "^0.9.4"
   }
 }

--- a/cdk/src/stack.ts
+++ b/cdk/src/stack.ts
@@ -6,6 +6,7 @@ import * as efs from 'aws-cdk-lib/aws-efs'
 import * as ssm from 'aws-cdk-lib/aws-ssm'
 import { HeyAmplifyApp } from './construct'
 import { PROJECT_ROOT } from './constants'
+import { getSvelteKitEnvironmentVariables } from './support'
 
 export class HeyAmplifyStack extends Stack {
   private readonly appName: string = this.node.tryGetContext('name')
@@ -23,9 +24,6 @@ export class HeyAmplifyStack extends Stack {
       'DISCORD_AUTH_CLIENT_ID',
       'DISCORD_AUTH_CLIENT_SECRET',
       'DISCORD_AUTH_REDIRECT_URI',
-      'VITE_HOST',
-      'VITE_NEXTAUTH_URL',
-      'VITE_NEXTAUTH_SECRET',
     ] as const
     // NOTE: this TypeScript trick is to say `secrets` should include key value pairs where the keys are one of the names in the array above
     const secrets: Partial<
@@ -68,6 +66,7 @@ export class HeyAmplifyStack extends Stack {
         dockerfile: 'Dockerfile',
         environment: {
           DATABASE_URL: `file:../db/${this.envName}.db`,
+          ...getSvelteKitEnvironmentVariables(this.envName),
         },
       },
       secrets,

--- a/cdk/src/stack.ts
+++ b/cdk/src/stack.ts
@@ -24,6 +24,7 @@ export class HeyAmplifyStack extends Stack {
       'DISCORD_AUTH_CLIENT_ID',
       'DISCORD_AUTH_CLIENT_SECRET',
       'DISCORD_AUTH_REDIRECT_URI',
+      'NEXTAUTH_SECRET',
     ] as const
     // NOTE: this TypeScript trick is to say `secrets` should include key value pairs where the keys are one of the names in the array above
     const secrets: Partial<

--- a/cdk/src/support.ts
+++ b/cdk/src/support.ts
@@ -1,0 +1,9 @@
+import { loadEnv } from 'vite'
+
+/**
+ * Gets environment variables required for Svelte-Kit build
+ * by default Vite's `loadEnv` will only load variables prefixed with "VITE_"
+ */
+export function getSvelteKitEnvironmentVariables(env: string) {
+  return loadEnv(env, new URL('../..', import.meta.url).pathname, ['VITE_'])
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,7 @@ importers:
       constructs: ^10.0.123
       source-map-support: ^0.5.21
       typescript: ^4.6.3
+      vite: ^2.9.12
       vite-node: ^0.9.4
     devDependencies:
       '@hey-amplify/tsconfig': link:../packages/tsconfig
@@ -99,6 +100,7 @@ importers:
       constructs: 10.1.9
       source-map-support: 0.5.21
       typescript: 4.6.4
+      vite: 2.9.12
       vite-node: 0.9.4
 
   packages/support:
@@ -3642,11 +3644,35 @@ packages:
       minimist: 1.2.6
       mlly: 0.5.2
       pathe: 0.2.0
-      vite: 2.9.9
+      vite: 2.9.12
     transitivePeerDependencies:
       - less
       - sass
       - stylus
+    dev: true
+
+  /vite/2.9.12:
+    resolution: {integrity: sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==}
+    engines: {node: '>=12.2.0'}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+    dependencies:
+      esbuild: 0.14.39
+      postcss: 8.4.13
+      resolve: 1.22.0
+      rollup: 2.73.0
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /vite/2.9.9:

--- a/src/lib/next-auth.ts
+++ b/src/lib/next-auth.ts
@@ -60,11 +60,11 @@ async function toSvelteKitResponse(
     headers: {},
   }
 
-  headers?.forEach(header => {
+  headers?.forEach((header) => {
     response.headers[header.key] = header.value
   })
 
-  response.headers['set-cookie'] = cookies?.map(item => {
+  response.headers['set-cookie'] = cookies?.map((item) => {
     return cookie.serialize(item.name, item.value, item.options)
   })
 
@@ -102,7 +102,7 @@ async function SKNextAuthHandler(
   } catch {
     // no formData passed
   }
-  options.secret = import.meta.env.VITE_NEXTAUTH_SECRET
+  options.secret = process.env.NEXTAUTH_SECRET
   const req: IncomingRequest = {
     host: import.meta.env.VITE_NEXTAUTH_URL,
     body,
@@ -131,7 +131,7 @@ export async function getServerSession(
   request: Request,
   options: NextAuthOptions
 ): Promise<Session | null> {
-  options.secret = import.meta.env.VITE_NEXTAUTH_SECRET
+  options.secret = process.env.NEXTAUTH_SECRET
 
   const session = await NextAuthHandler<Session>({
     req: {
@@ -156,6 +156,6 @@ export default (
   get: (req) => Promise<unknown>
   post: (req) => Promise<unknown>
 } => ({
-  get: req => SKNextAuthHandler(req, options),
-  post: req => SKNextAuthHandler(req, options),
+  get: (req) => SKNextAuthHandler(req, options),
+  post: (req) => SKNextAuthHandler(req, options),
 })

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -22,6 +22,7 @@ export function loadEnvVars() {
       'DISCORD_',
       'GITHUB_',
       'DATABASE_',
+      'NEXTAUTH_',
     ])
   )
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- loads `VITE_`-prefixed environment variables for Docker build
	- NOTE: these environment variables should be public-facing and _not_ "secret"
- changes `VITE_NEXTAUTH_SECRET` to `NEXTAUTH_SECRET`, corrects CDK stack


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
