### PR TITLE
fix: vitest in-source testing, remove client re-export

### DIFF
--- a/src/lib/discord/index.ts
+++ b/src/lib/discord/index.ts
@@ -1,6 +1,5 @@
 export * from './api'
 export * from './Bank'
-export * from './client'
 export * from './Command'
 export * from './CommandOption'
 export * from './CommandOptionChoice'

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import { createBot } from '$discord'
+import { createBot } from '$discord/client'
 // @ts-expect-error this file is externalized for build
 import { handler } from './handler.js'
 import express from 'express'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,12 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
-    "target": "es2022",
-    "module": "es2022",
-    "moduleResolution": "node",
     "paths": {
       "$lib": ["src/lib"],
       "$lib/*": ["src/lib/*"],
       "$discord": ["src/lib/discord"],
       "$discord/*": ["src/lib/discord/*"]
-    }
+    },
+    "types": ["vitest/importMeta"]
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

removes re-export of `client.ts` from `src/lib/discord/index.ts`, fixes in-source testing with Vitest

In the snippet below, we'll notice the error is thrown from a file different from the file being tested. This is because Vitest does not do any tree shaking, therefore all modules will be run when using an index file that is re-exporting many others.
```
> p test

> @aws-amplify/discord-bot@0.5.0 test /Users/josef/Documents/projects/aws-amplify/amplify-discord-bots
> vitest


 DEV  v0.12.10 /Users/josef/Documents/projects/aws-amplify/amplify-discord-bots

 ↓ src/lib/notifications.ts (1) [skipped]
 ❯ src/lib/discord/commands/contribute.ts (0)

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/lib/discord/commands/contribute.ts [ src/lib/discord/commands/contribute.ts ]
TypeError: createOption is not a function
 ❯ src/lib/discord/commands/thread.ts:185:8
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
