### PR TITLE
feat: add cloudfront

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -13,6 +13,7 @@
     "constructs": "^10.0.123",
     "source-map-support": "^0.5.21",
     "typescript": "^4.6.3",
+    "uuid": "^8.3.2",
     "vite": "^2.9.12",
     "vite-node": "^0.9.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,7 @@ importers:
       constructs: ^10.0.123
       source-map-support: ^0.5.21
       typescript: ^4.6.3
+      uuid: ^8.3.2
       vite: ^2.9.12
       vite-node: ^0.9.4
     devDependencies:
@@ -100,6 +101,7 @@ importers:
       constructs: 10.1.9
       source-map-support: 0.5.21
       typescript: 4.6.4
+      uuid: 8.3.2
       vite: 2.9.12
       vite-node: 0.9.4
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- adds CloudFront distribution in front of Application Load Balancer
- adds `X-HeyAmplify-Security-Token` header from CF to ALB
- adds listener rule to ALB to accept token header
- modifies default listener to return 403


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
