### PR TITLE
fix: loading env vars when parent directory has a space in it

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -18,7 +18,7 @@ const pkg = JSON.parse(await readFile(resolve('package.json'), 'utf-8'))
 export function loadEnvVars() {
   Object.assign(
     process.env,
-    loadEnv('development', new URL('.', import.meta.url).pathname, [
+    loadEnv('development', decodeURI(new URL('.', import.meta.url).pathname), [
       'DISCORD_',
       'GITHUB_',
       'DATABASE_',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- adds `decodeURI` to file URL of project directory


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
