### PR TITLE
fix: cloudfront should talk to origin over HTTP

### DIFF
--- a/cdk/src/construct.ts
+++ b/cdk/src/construct.ts
@@ -81,7 +81,6 @@ export class HeyAmplifyApp extends Construct {
             containerPort: 3000,
           },
           publicLoadBalancer: true, // needed for bridge to CF
-          protocol: elb.ApplicationProtocol.HTTP, // needed to force HTTP for bridge to CF (Origin Protocol Policy is defaulting to HTTPS although cert is not configured and ALB is not listening on port 443)
         }
       )
 
@@ -146,6 +145,7 @@ export class HeyAmplifyApp extends Construct {
               // send the X-HeyAmplify-Security-Token header to the ALB
               [xAmzSecurityTokenHeaderName]: xAmzSecurityTokenHeaderValue,
             },
+            protocolPolicy: cloudfront.OriginProtocolPolicy.HTTP_ONLY,
           }
         ),
         allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

<img width="180" alt="image" src="https://user-images.githubusercontent.com/5033303/175577887-a2dd2402-e9c1-4f71-a56c-a2f6c6532600.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
