### PR TITLE
fix: logging parsed error body

### DIFF
--- a/src/routes/api/webhooks/github-release.ts
+++ b/src/routes/api/webhooks/github-release.ts
@@ -58,7 +58,7 @@ export async function post({ request }) {
   // if response is not okay or if Discord did not return a 204
   // https://discord.com/developers/docs/topics/opcodes-and-status-codes#http
   if (!res.ok ) {
-    if (res.body) console.log(res.body)
+    if (res.body) console.log(await res.json())
     return {
       status: 400,
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* If the github webhook fails, log the parsed json body of the error message.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
