### PR TITLE
feat(cdk): add headers to cf cache key, pass to origin for webhook

### DIFF
--- a/cdk/src/components/hey-amplify-app.ts
+++ b/cdk/src/components/hey-amplify-app.ts
@@ -160,6 +160,16 @@ export class HeyAmplifyApp extends Construct {
     const xAmzSecurityTokenHeaderName = 'X-HeyAmplify-Security-Token'
     const xAmzSecurityTokenHeaderValue = uuid()
 
+    const headerAllowlist = [
+      'X-GitHub-Delivery',
+      'X-GitHub-Event',
+      'X-GitHub-Hook-ID',
+      'X-GitHub-Hook-Installation-Target-ID',
+      'X-GitHub-Hook-Installation-Target-Type',
+      'X-Hub-Signature',
+      'X-Hub-Signature-256',
+    ]
+
     // set up CloudFront
     const distribution = new cloudfront.Distribution(this, 'CFDistribution', {
       // domainNames and certificate needed for amplify.aws subdomain (connected to a Route53 hosted zone)
@@ -168,6 +178,9 @@ export class HeyAmplifyApp extends Construct {
       defaultBehavior: {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         cachePolicy: new cloudfront.CachePolicy(this, 'CachePolicy', {
+          headerBehavior: cloudfront.CacheHeaderBehavior.allowList(
+            ...headerAllowlist
+          ),
           queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
           cookieBehavior: cloudfront.CacheCookieBehavior.all(),
         }),

--- a/src/routes/api/webhooks/github-release.ts
+++ b/src/routes/api/webhooks/github-release.ts
@@ -361,7 +361,7 @@ if (import.meta.vitest) {
       'X-Hub-Signature-256':
         'sha256=df80b1d8f9348825f3edd5df44258cb6cfb822f7de73088372c5b54bdd970ce',
       'X-GitHub-Event': 'release',
-      'content-type': 'application/x-www-form-urlencoded',
+      'content-type': 'application/json',
     },
     body: {
       action: 'published',

--- a/src/routes/api/webhooks/github-release.ts
+++ b/src/routes/api/webhooks/github-release.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'node:crypto'
 import { MessageEmbed } from 'discord.js'
+import type { RequestHandler } from '@sveltejs/kit'
 
 function createReleaseMessage(payload) {
   const embed = new MessageEmbed()
@@ -20,9 +21,10 @@ function createReleaseMessage(payload) {
 }
 
 // https://gist.github.com/stigok/57d075c1cf2a609cb758898c0b202428
-function verifyGithubWebhookEvent(payloadbody, signature256: string) {
+function verifyGithubWebhookEvent(payloadbody: object, signature256: string) {
   if (!signature256) return false
   const token = process.env.GITHUB_WEBHOOK_SECRET
+  if (!token) console.error('GITHUB_WEBHOOK_SECRET is not set')
   const sig = Buffer.from(signature256 || '', 'utf8')
   const hmac = crypto.createHmac('sha256', token)
   const digest = Buffer.from(
@@ -35,13 +37,37 @@ function verifyGithubWebhookEvent(payloadbody, signature256: string) {
   return true
 }
 
-export async function post({ request }) {
-  const payload = await request.json()
+// application/x-www-form-urlencoded
+export const post: RequestHandler = async function post({ request }) {
+  let payload
+  try {
+    payload = await request.json()
+  } catch (error) {
+    return {
+      status: 400,
+      body: {
+        errors: [
+          {
+            message: `Invalid payload: ${error.message}`,
+          },
+        ],
+      },
+    }
+  }
 
   if (!import.meta.vitest) {
     const sig256 = request.headers.get('x-hub-signature-256')
     if (!verifyGithubWebhookEvent(payload, sig256)) {
-      return { status: 403 }
+      return {
+        status: 403,
+        body: {
+          errors: [
+            {
+              message: 'Unable to verify signature',
+            },
+          ],
+        },
+      }
     }
   }
 
@@ -81,7 +107,7 @@ if (import.meta.vitest) {
       'X-Hub-Signature-256':
         'sha256=df80b1d8f9348825f3edd5df44258cb6cfb822f7de73088372c5b54bdd970ce0',
       'X-GitHub-Event': 'release',
-      'Content-Type': 'application/json',
+      'content-type': 'application/json',
     },
     body: {
       action: 'published',
@@ -335,7 +361,7 @@ if (import.meta.vitest) {
       'X-Hub-Signature-256':
         'sha256=df80b1d8f9348825f3edd5df44258cb6cfb822f7de73088372c5b54bdd970ce',
       'X-GitHub-Event': 'release',
-      'Content-Type': 'application/json',
+      'content-type': 'application/x-www-form-urlencoded',
     },
     body: {
       action: 'published',
@@ -593,7 +619,7 @@ if (import.meta.vitest) {
         )
       ).toBeTruthy()
     })
-    
+
     it('should return false with a jumbled payload', () => {
       expect(
         verifyGithubWebhookEvent(

--- a/tests/server.ts
+++ b/tests/server.ts
@@ -8,7 +8,12 @@ import { beforeAll } from 'vitest'
 import type { Server } from 'node:http'
 import type { Session } from 'next-auth'
 import { it } from 'vitest'
-import { mockedPublished, mockedCreated, mockedPreReleased, mockedReleased } from './mock/github-webhook'
+import {
+  mockedPublished,
+  mockedCreated,
+  mockedPreReleased,
+  mockedReleased,
+} from './mock/github-webhook'
 
 let app: Express.Application
 const session: Session = {
@@ -104,6 +109,14 @@ describe('webhooks', () => {
       expect(response.status).toBe(403)
     })
 
+    it('should return 403 with invalid auth header', async () => {
+      const response = await request(app)
+        .post('/api/webhooks/github-release')
+        .send(mockedReleased.body)
+        .set({ 'X-Hub-Signature-256': 'invalid' })
+      expect(response.status).toBe(403)
+    })
+
     it('should return 400 if webhook URL is bad', async () => {
       const url = process.env.DISCORD_WEBHOOK_URL_RELEASES
       process.env.DISCORD_WEBHOOK_URL_RELEASES =
@@ -116,37 +129,48 @@ describe('webhooks', () => {
       process.env.DISCORD_WEBHOOK_URL_RELEASES = url
     })
 
+    it('should return 400 if invalid content-type', async () => {
+      // if webhook in GitHub is set to application/x-www-url-encoded
+      const response = await request(app)
+        .post('/api/webhooks/github-release')
+        .send(
+          `payload=${encodeURIComponent(JSON.stringify(mockedReleased.body))}`
+        )
+        .set({ 'Content-Type': 'application/x-www-url-encoded' })
+      expect(response.status).toBe(400)
+      // TODO: test for correct error message
+    })
+
     it('should return 201 if everything is correct', async () => {
       const response = await request(app)
-      .post('/api/webhooks/github-release')
-      .send(mockedReleased.body)
-      .set(mockedReleased.headers)
+        .post('/api/webhooks/github-release')
+        .send(mockedReleased.body)
+        .set(mockedReleased.headers)
       expect(response.status).toBe(201)
     })
 
     it(`should return 204 is event action is not 'released'`, async () => {
       const response = await request(app)
-      .post('/api/webhooks/github-release')
-      .send(mockedCreated.body)
-      .set(mockedCreated.headers)
+        .post('/api/webhooks/github-release')
+        .send(mockedCreated.body)
+        .set(mockedCreated.headers)
       expect(response.status).toBe(204)
     })
 
     it(`should return 204 is event action is not 'released'`, async () => {
       const response = await request(app)
-      .post('/api/webhooks/github-release')
-      .send(mockedPublished.body)
-      .set(mockedPublished.headers)
+        .post('/api/webhooks/github-release')
+        .send(mockedPublished.body)
+        .set(mockedPublished.headers)
       expect(response.status).toBe(204)
     })
 
     it(`should return 204 is event action is not 'released'`, async () => {
       const response = await request(app)
-      .post('/api/webhooks/github-release')
-      .send(mockedPreReleased.body)
-      .set(mockedPreReleased.headers)
+        .post('/api/webhooks/github-release')
+        .send(mockedPreReleased.body)
+        .set(mockedPreReleased.headers)
       expect(response.status).toBe(204)
     })
-
   })
 })


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- adds headers to CloudFront cache key to pass to origin (GitHub webhook sha header was being stripped from the request sent to the app)
- adds error messages to endpoint
- adds tests for invalid payload body (to account for application/x-www-url-encoded types)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
