### PR TITLE
fix(bot): thread command to respond correctly outside help, ref #179

### DIFF
--- a/src/lib/discord/client.ts
+++ b/src/lib/discord/client.ts
@@ -1,12 +1,13 @@
 import { Client, Intents, MessageEmbed } from 'discord.js'
 import { createDiscordCommandBank } from '$discord'
-import type { Message, StartThreadOptions, ThreadChannel } from 'discord.js'
 import { prisma } from '$lib/db'
 // manually import the commands
 import giverole from './commands/giverole'
 import contribute from './commands/contribute'
 import thread, { PREFIXES } from './commands/thread'
 import github from './commands/github'
+import { isHelpChannel, isThreadWithinHelpChannel } from './support'
+import type { Message, StartThreadOptions, ThreadChannel } from 'discord.js'
 
 export const client = new Client({
   intents: [
@@ -35,8 +36,7 @@ client.on('messageCreate', async (message: Message) => {
   if (
     !message.author.bot &&
     message.channel.type === 'GUILD_TEXT' &&
-    (message.channel.name.startsWith('help-') ||
-      message.channel.name.endsWith('-help'))
+    isHelpChannel(message.channel)
   ) {
     const options: StartThreadOptions = {
       name: `${PREFIXES.open}${message.content.slice(0, 140)}...`,
@@ -75,8 +75,7 @@ client.on('messageCreate', async (message: Message) => {
   if (
     message.channel.type === 'GUILD_PUBLIC_THREAD' &&
     !message.author.bot &&
-    (message.channel.parent?.name.startsWith('help-') ||
-      message.channel.parent?.name.endsWith('-help'))
+    isThreadWithinHelpChannel(message.channel)
   ) {
     const record = await prisma.question.upsert({
       where: { threadId: message.channel.id },

--- a/src/lib/discord/commands/thread.ts
+++ b/src/lib/discord/commands/thread.ts
@@ -1,7 +1,8 @@
 import { MessageEmbed } from 'discord.js'
 import { createCommand, createOption } from '$discord'
-import type { InteractionReplyOptions, ThreadChannel } from 'discord.js'
 import { prisma } from '$lib/db'
+import { isThreadWithinHelpChannel } from '../support'
+import type { InteractionReplyOptions, ThreadChannel } from 'discord.js'
 
 export const PREFIXES = {
   solved: '✅ - ',
@@ -15,7 +16,7 @@ async function handler(interaction): Promise<InteractionReplyOptions | string> {
     where: { threadId: channel.id },
   })
 
-  if (!channel.isThread()) {
+  if (!channel.isThread() || !isThreadWithinHelpChannel(channel)) {
     const embed = new MessageEmbed()
     embed.setColor('#ff9900')
     embed.setDescription(

--- a/src/lib/discord/support.ts
+++ b/src/lib/discord/support.ts
@@ -1,3 +1,5 @@
+import type { TextChannel, ThreadChannel } from 'discord.js'
+
 export function generateResponse(content, embeds?) {
   return {
     tts: false,
@@ -5,4 +7,15 @@ export function generateResponse(content, embeds?) {
     embeds,
     allowed_mentions: [],
   }
+}
+
+export function isHelpChannel(channel: TextChannel) {
+  return channel.name.startsWith('help-') || channel.name.endsWith('-help')
+}
+
+export function isThreadWithinHelpChannel(channel: ThreadChannel) {
+  return (
+    channel.parent?.name.startsWith('help-') ||
+    channel.parent?.name.endsWith('-help')
+  )
 }


### PR DESCRIPTION
*Issue #, if available:*

fixes #179 

*Description of changes:*

- adds two helpers `isHelpChannel` and `isThreadWithinHelpChannel`
- adds conditional to thread command handler to check if thread is within help channel 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
