### PR TITLE
chore: rename ci action to run-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci
+name: run-ci
 on:
   push:
     branches:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- renames `ci` to `run-ci`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
