### PR TITLE
fix: changing next auth api routes to all caps  

### DIFF
--- a/src/lib/discord/api.ts
+++ b/src/lib/discord/api.ts
@@ -39,19 +39,19 @@ export class DiscordApi extends REST implements IDiscordApi {
   }
 
   public get(url: string): Promise<unknown> {
-    return this._request('get', url)
+    return this._request('GET', url)
   }
 
   public post(url: string, payload?: unknown): Promise<unknown> {
-    return this._request('post', url, payload)
+    return this._request('POST', url, payload)
   }
 
   public put(url: string, payload?: unknown): Promise<unknown> {
-    return this._request('put', url, payload)
+    return this._request('PUT', url, payload)
   }
 
   public delete(url: string, payload?: unknown): Promise<unknown> {
-    return this._request('delete', url, payload)
+    return this._request('DELETE', url, payload)
   }
 }
 

--- a/src/lib/next-auth.ts
+++ b/src/lib/next-auth.ts
@@ -205,9 +205,9 @@ export async function getServerSession(
 export default (
   options: NextAuthOptions
 ): {
-  get: (req) => Promise<unknown>
-  post: (req) => Promise<unknown>
+  GET: (req) => Promise<unknown>
+  POST: (req) => Promise<unknown>
 } => ({
-  get: (req) => SKNextAuthHandler(req, options),
-  post: (req) => SKNextAuthHandler(req, options),
+  GET: (req) => SKNextAuthHandler(req, options),
+  POST: (req) => SKNextAuthHandler(req, options),
 })

--- a/src/routes/api/auth/[...nextauth].ts
+++ b/src/routes/api/auth/[...nextauth].ts
@@ -1,3 +1,3 @@
 import { default as NextAuth, options } from '$lib/next-auth'
 
-export const { get, post } = NextAuth(options)
+export const { GET, POST } = NextAuth(options)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- nextAuth api routes are now in all caps
- also changing requests in `api.ts` to be all caps
 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
