### PR TITLE
fix(bot): enforce uniqueness on question ID + participant ID

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,8 @@ model Participation {
   // @TODO - track role at the time of participation, accounts for users that _leave_ "staff"
   participantId    String
   participantRoles DiscordRole[]
+
+  @@unique([questionId, participantId])
 }
 
 model DiscordRole {

--- a/src/lib/discord/client.ts
+++ b/src/lib/discord/client.ts
@@ -180,9 +180,13 @@ client.on('messageCreate', async (message: Message) => {
             // participation record
             participation: {
               connectOrCreate: {
-                where: { id: message.author.id },
+                where: {
+                  questionId_participantId: {
+                    questionId: record.id,
+                    participantId: message.author.id,
+                  },
+                },
                 create: {
-                  id: message.author.id,
                   // DiscordUser
                   participant: {
                     connectOrCreate: {
@@ -208,10 +212,12 @@ client.on('messageCreate', async (message: Message) => {
             },
           },
         })
-        console.log('Successfully updated participants')
+        console.log(
+          `Successfully updated participants for question ${record.id}`
+        )
       }
     } catch (error) {
-      console.error('Unable to update participants', error)
+      console.error(`Unable to update participants`, error)
     }
   }
 })


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- fixes behavior where participant (`DiscordUser`)'s record is remapped to the most recent question participation
- enforces uniqueness on Participation model to ensure question ID and participant ID are added once, and participants (i.e. `DiscordUser`'s can have participations across multiple questions)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
