### PR TITLE
fix(app): do not restrict profile/link when not logged in with discord

### DIFF
--- a/src/routes/profile/link.svelte
+++ b/src/routes/profile/link.svelte
@@ -2,9 +2,6 @@
   import type { Load } from '@sveltejs/kit'
 
   export const load: Load = async ({ session }) => {
-    if (!session?.user) {
-      return { redirect: '/restricted', status: 302 }
-    }
     return {
       props: {},
     }
@@ -17,14 +14,15 @@
   import LoginButton from '$lib/LoginButton.svelte'
 
   let formGitHub
-  let formDiscord
 </script>
 
 <Content>
   <Grid>
     <Row>
       <Column>
-        {#if $session?.user?.github}
+        {#if !$session?.user}
+          <p>You do not appear to be logged in. First, login with Discord</p>
+        {:else if $session?.user?.github}
           <p>
             Thanks for linking your GitHub account! It is now safe to close this
             page


### PR DESCRIPTION
*Issue #, if available:*

closes #238

*Description of changes:*

- removes restrictions and redirect in favor of helpful messaging


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
