### PR TITLE
fix(bot): track answer participation record, owner is a participant

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,14 +46,14 @@ model Participation {
   // @TODO - track role at the time of participation, accounts for users that _leave_ "staff"
   participantId    String
   participantRoles DiscordRole[]
+  answer           Answer?
 
   @@unique([questionId, participantId])
 }
 
 model DiscordRole {
-  id            String           @id @unique
+  id            String           @id @unique // Discord Role ID
   participation Participation[]
-  // @TODO - link up with AccessLevelRole?
   role          AccessLevelRole?
 }
 
@@ -63,6 +63,7 @@ model DiscordUser {
   accountId      String?         @unique
   participations Participation[]
   // we are not storing roles on users because we want to capture point-in-time roles for participation records
+  answers        Answer[]
 }
 
 model GitHubDiscussion {
@@ -72,16 +73,19 @@ model GitHubDiscussion {
 }
 
 model Answer {
-  id         String   @id @default(cuid())
-  selectedAt DateTime @default(now())
-  selectedBy String // Discord user ID
-  createdAt  DateTime
-  updatedAt  DateTime @updatedAt
-  ownerId    String // Discord member that answered the question
-  content    String
-  url        String?
-  question   Question @relation(fields: [questionId], references: [id])
-  questionId String   @unique // Question.id
+  id              String        @id @default(cuid())
+  selectedAt      DateTime      @default(now())
+  selectedBy      String // Discord user ID
+  createdAt       DateTime
+  updatedAt       DateTime      @updatedAt
+  owner           DiscordUser   @relation(fields: [ownerId], references: [id])
+  ownerId         String // Discord member that answered the question
+  content         String
+  url             String?
+  question        Question      @relation(fields: [questionId], references: [id])
+  questionId      String        @unique // Question.id
+  participation   Participation @relation(fields: [participationId], references: [id])
+  participationId String        @unique
 }
 
 // SQLite does not support enums, https://github.com/prisma/prisma/issues/2219

--- a/src/lib/discord/client.ts
+++ b/src/lib/discord/client.ts
@@ -134,7 +134,9 @@ client.on('messageCreate', async (message: Message) => {
   ) {
     let record
     try {
-      // if we need to backfill the question, we'll need to fetch all messages from the thread first
+      /**
+       * @TODO if we need to backfill the question, we'll need to fetch all messages from the thread first
+       */
       record = await prisma.question.upsert({
         where: { threadId: message.channel.id },
         update: {
@@ -145,7 +147,7 @@ client.on('messageCreate', async (message: Message) => {
             await message.channel.fetchStarterMessage()
           ).author.id as string,
           threadId: message.channel.id,
-          channelName: message.channel.parent.name,
+          channelName: message.channel.parent!.name,
           title: message.channel.name,
           createdAt: message.channel.createdAt as Date,
           url: message.url,
@@ -168,9 +170,9 @@ client.on('messageCreate', async (message: Message) => {
 
     try {
       /**
-       * add the participants separately only if they are not the owners of the question
+       * add the participants separately
        */
-      if (record && record.ownerId !== message.author.id) {
+      if (record) {
         const roleIds = message.member?.roles.cache.map((role) => role.id)
         await prisma.question.update({
           where: {

--- a/src/lib/discord/commands/select-answer.ts
+++ b/src/lib/discord/commands/select-answer.ts
@@ -83,16 +83,28 @@ export const handler = async (
 
   // update question with new answer
   await prisma.question.update({
-    where: { id: record.id },
+    where: { id: record!.id },
     data: {
       answer: {
         create: {
           id: answer,
           content: interaction.targetMessage.content,
-          ownerId: interaction.targetMessage.author.id,
+          owner: {
+            connect: {
+              id: interaction.targetMessage.author.id,
+            },
+          },
           createdAt: interaction.targetMessage.createdAt,
           selectedBy: interaction.user.id,
           url: interaction.targetMessage.url,
+          participation: {
+            connect: {
+              questionId_participantId: {
+                participantId: interaction.targetMessage.author.id,
+                questionId: record!.id,
+              },
+            },
+          },
         },
       },
     },
@@ -133,7 +145,9 @@ export const handler = async (
       ].join('\n')
     )
     console.info(
-      `User ${interaction.user.id} selected answer ${answer} to question ${record.id}`
+      `User ${interaction.user.id} selected answer ${answer} to question ${
+        record!.id
+      }`
     )
   }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- links answers to their participation records
- adds participation records for owners (required to select an answer's participation record and capture point-in-time roles)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
