### PR TITLE
fix: adding GitHub Discussion that matches schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,7 +67,7 @@ model DiscordUser {
 }
 
 model GitHubDiscussion {
-  id       String    @id @unique
+  id       String    @id @unique // GitHub Discussion ID 
   url      String
   Question Question?
 }

--- a/src/lib/discord/commands/admin.ts
+++ b/src/lib/discord/commands/admin.ts
@@ -94,7 +94,6 @@ async function addDiscussion(discussion, userId: string, record: Question) {
   const githubDiscussion = {
     id: discussion?.createDiscussion?.discussion?.id,
     url: discussion?.createDiscussion?.discussion?.url,
-    createdBy: userId,
     Question: {
       connect: {
         id: record.id,
@@ -102,9 +101,10 @@ async function addDiscussion(discussion, userId: string, record: Question) {
     },
   }
   try {
-    await prisma.gitHubDiscussion.create({
+    const ghDiscussion = await prisma.gitHubDiscussion.create({
       data: githubDiscussion,
     })
+    console.log(`Successfully created new GitHub Discussion ${ghDiscussion.id}`)
   } catch (error) {
     console.error(`Failed to add discussion to db ${error.message}`)
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing invocation of `prisma.gitHubDiscussion.create` to only include fields in the schema. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
