### PR TITLE
feat(vite-plugin-server): allow disabled dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,7 @@ const base: UserConfig = {
     },
     include: ['@carbon/charts'],
   },
-  plugins: [sveltekit(), server()],
+  plugins: [sveltekit(), server({ dev: false })],
   resolve: {
     alias: {
       $discord: relative('./src/lib/discord'),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- adds support with `vite-plugin-server` to disable the server in dev mode, allows bot to be created in `hooks.ts` and prevents clashing ports


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
