### PR TITLE
feat: add action to remove pending-author label

### DIFF
--- a/.github/workflows/issues-pending-author.yml
+++ b/.github/workflows/issues-pending-author.yml
@@ -1,0 +1,15 @@
+name: issue-pending-response
+on:
+  issue_comment:
+    types: [created]
+env:
+  PENDING_RESPONSE_LABEL: pending-author
+jobs:
+  issue_commented:
+    if: ${{ !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, env.PENDING_RESPONSE_LABEL) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: siegerts/pending-author-response@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pending-response-label: ${{ env.PENDING_RESPONSE_LABEL }}

--- a/.github/workflows/issues-pending-author.yml
+++ b/.github/workflows/issues-pending-author.yml
@@ -3,7 +3,7 @@ on:
   issue_comment:
     types: [created]
 env:
-  PENDING_RESPONSE_LABEL: pending-author
+  PENDING_RESPONSE_LABEL: 'pending: author'
 jobs:
   issue_commented:
     if: ${{ !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, env.PENDING_RESPONSE_LABEL) }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- adds new GitHub Action to automatically remove the `pending-author` label when the author has responded


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
