### PR TITLE
fix(bot): remove usage of $env from sveltekit

### DIFF
--- a/src/lib/discord/commands.ts
+++ b/src/lib/discord/commands.ts
@@ -13,7 +13,6 @@ import {
   type ContextMenuCommandInteraction,
   type InteractionReplyOptions,
 } from 'discord.js'
-import { env } from '$env/dynamic/private'
 import { prisma } from '$lib/db'
 import { FEATURE_TYPES } from '$lib/constants'
 import * as admin from './commands/admin'
@@ -133,7 +132,10 @@ export async function registerCommands(
   try {
     console.log(`Started refreshing guild slash (/) commands for ${guild}.`)
     response = (await api.put(
-      Routes.applicationGuildCommands(env.DISCORD_APP_ID as string, guild),
+      Routes.applicationGuildCommands(
+        process.env.DISCORD_APP_ID as string,
+        guild
+      ),
       payload
     )) as RESTPostAPIApplicationGuildCommandsResult
     console.log(
@@ -183,7 +185,10 @@ export async function registerCommand(
   try {
     console.log(`Started ${messaging}`)
     response = (await api.post(
-      Routes.applicationGuildCommands(env.DISCORD_APP_ID as string, guild),
+      Routes.applicationGuildCommands(
+        process.env.DISCORD_APP_ID as string,
+        guild
+      ),
       payload
     )) as RESTPostAPIApplicationGuildCommandsResult
     console.log(`Successfully ${messaging}`)
@@ -234,7 +239,10 @@ export async function syncRegisteredCommandsForGuild(
   let registeredCommands = []
   try {
     registeredCommands = (await api.get(
-      Routes.applicationGuildCommands(env.DISCORD_APP_ID as string, guildId)
+      Routes.applicationGuildCommands(
+        process.env.DISCORD_APP_ID as string,
+        guildId
+      )
     )) as RESTGetAPIApplicationGuildCommandsResult
   } catch (error) {
     console.error(
@@ -278,7 +286,7 @@ export async function syncRegisteredCommandsForGuild(
 export async function unregisterCommand(commandId: string, guildId: string) {
   const registered = (await api.get(
     Routes.applicationGuildCommand(
-      env.DISCORD_APP_ID as string,
+      process.env.DISCORD_APP_ID as string,
       guildId,
       commandId
     )
@@ -286,7 +294,7 @@ export async function unregisterCommand(commandId: string, guildId: string) {
   try {
     await api.delete(
       Routes.applicationGuildCommand(
-        env.DISCORD_APP_ID as string,
+        process.env.DISCORD_APP_ID as string,
         guildId,
         commandId
       )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

removes usage of `$env` in favor of `process.env` for Node client code


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
