### PR TITLE
feat(actions): allow pre-semver version options, enable NEXTAUTH secrets to SSM, rolling release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,6 +7,9 @@ on:
         description: 'Type of release'
         options: # put in ascending order to not accidentally cut a "major" release PR
           - prerelease
+          - prepatch
+          - preminor
+          - premajor
           - patch
           - minor
           - major

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
             return context.payload.pull_request.title.replace(/release\: /, '');
   prerelease:
     needs: verify-run
-    if: ${{ fromJSON(needs.verify-run.outputs.is-prerelease) == true }}
     uses: ./.github/workflows/release-env.yml
     secrets: inherit
     with:

--- a/cdk/src/app-github-actions.ts
+++ b/cdk/src/app-github-actions.ts
@@ -78,6 +78,14 @@ export class GitHubActionsStack extends cdk.Stack {
               actions: ['sts:AssumeRole'],
               resources: [`arn:aws:iam::${this.account}:role/cdk-*`],
             }),
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: ['ssm:GetParametersByPath'],
+              resources: [
+                // allow access to all "setup" parameters in the account
+                `arn:aws:ssm:*:${this.account}:parameter/app/*/_setup/*`,
+              ],
+            }),
           ],
         }),
       },

--- a/packages/support/src/secrets.ts
+++ b/packages/support/src/secrets.ts
@@ -44,7 +44,7 @@ export function createSecretKey(
 export function loadSecrets(
   envName = '_local',
   envDir: string = process.cwd(),
-  envPrefix: string | string[] = ['DISCORD_', 'GITHUB_', 'PUBLIC_']
+  envPrefix: string | string[] = ['DISCORD_', 'GITHUB_', 'PUBLIC_', 'NEXTAUTH_']
 ): Record<string, string> {
   let prefixes = envPrefix
   if (prefixes) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- modifies IAM policy of assumed role to grant access to "setup" secrets (e.g. manually created Route53 Hosted Zone ID)
- modifies release pipeline to _always_ deploy to staging environment. This ensures all changes into prod are first rolled into staging. In the event the container fails to start, this will only impact the staging environment with an estimated downtime of 20m-2hrs
- adds `NEXTAUTH` to the list of approved secret prefixes in order for support CLI to create secrets from dotenv to AWS SSM
- adds additional inputs to `create-release` action: `prepatch`, `preminor`, `premajor`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
