### PR TITLE
chore(app): port api routes to use guildId from locals

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -39,7 +39,7 @@ const handleSession: Handle = async ({ event, resolve }) => {
  * Add additional user data to the session
  */
 const handleSessionUser: Handle = async ({ event, resolve }) => {
-  const { session } = event.locals
+  const session = event.locals.session || {}
 
   let savedGuild = null
   const cookies = event.request.headers.get('cookie')
@@ -48,7 +48,7 @@ const handleSessionUser: Handle = async ({ event, resolve }) => {
     savedGuild = parsed['hey-amplify.guild']
   }
 
-  if (!session.guild) {
+  if (!session?.guild) {
     if (savedGuild) {
       session.guild = savedGuild
     } else {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -48,15 +48,15 @@ const handleSessionUser: Handle = async ({ event, resolve }) => {
     savedGuild = parsed['hey-amplify.guild']
   }
 
-  if (session?.user) {
-    if (!session.guild) {
-      if (savedGuild) {
-        session.guild = savedGuild
-      } else {
-        session.guild = import.meta.env.VITE_DISCORD_GUILD_ID
-      }
+  if (!session.guild) {
+    if (savedGuild) {
+      session.guild = savedGuild
+    } else {
+      session.guild = import.meta.env.VITE_DISCORD_GUILD_ID
     }
+  }
 
+  if (session?.user) {
     event.locals.session = session
     const user = await prisma.user.findUnique({
       where: {

--- a/src/routes/api/discord/[userId]/+server.ts
+++ b/src/routes/api/discord/[userId]/+server.ts
@@ -3,9 +3,7 @@ import { api } from '$discord/api'
 import type { RequestHandler } from '@sveltejs/kit'
 import type { APIGuildMember } from 'discord-api-types/v10'
 
-const guildId = import.meta.env.VITE_DISCORD_GUILD_ID
-
-async function getDiscordUsername(userId: string) {
+async function getDiscordUsername(userId: string, guildId: string) {
   try {
     const guildMember = (await api.get(Routes.guildMember(guildId, userId))) as
       | APIGuildMember
@@ -21,7 +19,7 @@ async function getDiscordUsername(userId: string) {
   return 'unknown'
 }
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, locals }) => {
   const { userId } = params
   if (!userId) {
     return new Response(
@@ -32,6 +30,6 @@ export const GET: RequestHandler = async ({ params }) => {
       }
     )
   }
-  const result = await getDiscordUsername(userId)
+  const result = await getDiscordUsername(userId, locals.session.guild)
   return new Response(result)
 }

--- a/src/routes/api/webhooks/github-org-membership/+server.ts
+++ b/src/routes/api/webhooks/github-org-membership/+server.ts
@@ -32,7 +32,8 @@ async function getDiscordUserId(ghUserId: string) {
   throw new Error(`Discord account not found for GitHub user ${ghUserId}`)
 }
 
-export const POST: RequestHandler = async function post({ request }) {
+export const POST: RequestHandler = async function post({ request, locals }) {
+  const guildId = locals.session.guild
   let rolesApplied, guildMemberId
   let payload
   try {
@@ -82,7 +83,7 @@ export const POST: RequestHandler = async function post({ request }) {
    */
   const config = await prisma.configuration.findUnique({
     where: {
-      id: import.meta.env.VITE_DISCORD_GUILD_ID,
+      id: guildId,
     },
     select: {
       id: true,

--- a/src/routes/questions/+page.server.ts
+++ b/src/routes/questions/+page.server.ts
@@ -1,10 +1,10 @@
 import { prisma } from '$lib/db'
 import type { PageServerLoad } from './$types'
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({ locals }) => {
   const questions = await prisma.question.findMany({
     where: {
-      guildId: import.meta.env.VITE_DISCORD_GUILD_ID,
+      guildId: locals.session.guild,
     },
     select: {
       id: true,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- migrates API routes to use`locals.session.guild` instead of `import.meta.env.VITE_DISCORD_GUILD_ID`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
