### PR TITLE
chore(app): migrate applyRoles to use guildId from params

### DIFF
--- a/src/lib/github/apply-roles.ts
+++ b/src/lib/github/apply-roles.ts
@@ -97,7 +97,8 @@ export async function isContributor(
 export async function applyRoles(
   userId: string,
   ghUserId: string,
-  accessToken: string
+  accessToken: string,
+  guildId: string = import.meta.env.VITE_DISCORD_GUILD_ID
 ) {
   let discUserId
   let staffResponse = true
@@ -126,7 +127,7 @@ export async function applyRoles(
 
   const config = await prisma.configuration.findUnique({
     where: {
-      id: import.meta.env.VITE_DISCORD_GUILD_ID,
+      id: guildId,
     },
     select: {
       id: true,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

migrates usage of `import.meta.env.VITE_DISCORD_GUILD_ID` to use `guildId` from params

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
