### PR TITLE
fix(app): always set guild cookie on init

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -16,3 +16,6 @@ export const FEATURE_TYPES = {
   COMMAND: 'COMMAND',
   INTEGRATION: 'INTEGRATION',
 }
+
+export const APP_COOKIE_BASE = 'hey-amplify'
+export const GUILD_COOKIE = `${APP_COOKIE_BASE}.guild`

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -7,15 +7,18 @@ export const load: LayoutServerLoad = async ({ locals }) => {
   const botGuilds = (await api.get(Routes.userGuilds())) as APIGuild[]
 
   const guilds = []
-  for (const guild of botGuilds) {
-    try {
-      await api.get(Routes.guildMember(guild.id, locals.session.user.id))
-      guilds.push(guild)
-    } catch (error) {
-      // user is not a member of this guild, this messaging can be safely ignored but is available for debugging
-      console.warn(
-        `[ignore] Error fetching guild member for ${guild.id}: ${error}`
-      )
+  // only attempt to fetch guild memberships if the user is logged in
+  if (locals.session?.user) {
+    for (const guild of botGuilds) {
+      try {
+        await api.get(Routes.guildMember(guild.id, locals.session.user.id))
+        guilds.push(guild)
+      } catch (error) {
+        // user is not a member of this guild, this messaging can be safely ignored but is available for debugging
+        console.warn(
+          `[ignore] Error fetching guild member for ${guild.id}: ${error}`
+        )
+      }
     }
   }
 

--- a/src/routes/api/switch-guild/+server.ts
+++ b/src/routes/api/switch-guild/+server.ts
@@ -1,13 +1,11 @@
 import { type RequestHandler } from '@sveltejs/kit'
 import cookie from 'cookie'
 import { z } from 'zod'
+import { GUILD_COOKIE } from '$lib/constants'
 
 const schema = z.object({
   guildId: z.string().min(1),
 })
-
-const APP_COOKIE_BASE = 'hey-amplify'
-const GUILD_COOKIE = `${APP_COOKIE_BASE}.guild`
 
 export const POST: RequestHandler = async ({ request, locals, url }) => {
   let guildId


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

sets guild cookie on first request. previously this cookie would only be set after the server switch. This change will make it so the cookie is set on first request to the site, mitigating issues related to loading server configuration for admin page


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
