### PR TITLE
fix(bot): Discord thread titles have a max of 100 characters

### DIFF
--- a/src/lib/discord/client.ts
+++ b/src/lib/discord/client.ts
@@ -136,7 +136,7 @@ client.on(Events.MessageCreate, async (message: Message) => {
     isHelpChannel(message.channel)
   ) {
     const options: StartThreadOptions = {
-      name: `${PREFIXES.open}${message.content.slice(0, 140)}...`,
+      name: `${PREFIXES.open}${message.content.slice(0, 90)}...`,
       autoArchiveDuration: 60,
     }
     const thread: ThreadChannel = await message.startThread(options)
@@ -310,6 +310,11 @@ process.on('SIGINT', () => {
   console.log('destroying client')
   client?.destroy()
   process.exit(0)
+})
+
+process.on('exit', () => {
+  console.log('destroying client')
+  client?.destroy()
 })
 
 if (import.meta.hot) {

--- a/src/lib/discord/commands/thread.ts
+++ b/src/lib/discord/commands/thread.ts
@@ -98,7 +98,7 @@ export async function handler(
 
     // rename the thread
     const [{ value: title }] = args.rename.options
-    const name = `${parseTitlePrefix(channel.name) || ''}${title.slice(0, 140)}`
+    const name = `${parseTitlePrefix(channel.name) || ''}${title.slice(0, 90)}`
     if (await channel.setName(name)) {
       try {
         await prisma.question.update({


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

modifies Discord threading to trim at 90 characters of original message. Fixes issue where thread title would exceed the constraint of 100 characters, where we're including the thread prefix `? - ` (4 chars) and suffix `...` (3 chars)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
