### PR TITLE
feat(app): "view in discord" opens in discord app client

### DIFF
--- a/src/routes/questions/[id]/+page.svelte
+++ b/src/routes/questions/[id]/+page.svelte
@@ -25,7 +25,10 @@
         <p>
           {question.title}
         </p>
-        <Link href="{question.url}">View in Discord<Launch /></Link>
+        <Link href="{question.url?.replace(/^https/, 'discord')}">
+          View in Discord
+          <Launch />
+        </Link>
       </Column>
     </Row>
   </Grid>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Modifies "view in Discord" link to open in the Discord app client rather than the same tab over https


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
