### PR TITLE
chore(bot): improve thread handling

### DIFF
--- a/src/lib/discord/commands/thread.ts
+++ b/src/lib/discord/commands/thread.ts
@@ -38,10 +38,15 @@ export async function handler(
   const record = await prisma.question.findUnique({
     where: { threadId: channel.id },
   })
+  const subcommand = interaction.options.getSubcommand()
+
+  /**
+   * Create embed for reply
+   */
+  const embed = new EmbedBuilder()
+  embed.setColor('#ff9900')
 
   if (!channel.isThread() || !isThreadWithinHelpChannel(channel)) {
-    const embed = new EmbedBuilder()
-    embed.setColor('#ff9900')
     embed.setDescription(
       'This command only works in public threads within help channels.'
     )
@@ -57,143 +62,107 @@ export async function handler(
     interaction.user.id !== record?.ownerId &&
     !(await isAdminOrStaff(interaction.member as GuildMember))
   ) {
-    const embed = new EmbedBuilder()
-    embed.setColor('#ff9900')
     embed.setDescription('Only owners of questions can use this command.')
     return { embeds: [embed], ephemeral: true }
   }
 
-  /**
-   * @TODO - refactor for explicit typing, ease of use
-   */
-  const args = interaction.options.data.reduce((acc, current) => {
-    return {
-      ...acc,
-      [current.name]: current,
-    }
-  }, {})
-
-  if (args.rename) {
-    const embed = new EmbedBuilder()
-    embed.setColor('#ff9900')
-
-    // check if thread has been renamed within 10 minutes
-    const renames = messages.filter(
-      (m) =>
-        m.author.id === channel.ownerId &&
-        m.type === MessageType.ChannelNameChange
-    )
-    const lastRenameTimestamp = renames.first()?.createdTimestamp
-    if (lastRenameTimestamp) {
-      const minutesSinceLastRename = Math.floor(
-        (Date.now() - lastRenameTimestamp) / 1000 / 60
+  switch (subcommand) {
+    case 'rename': {
+      // check if thread has been renamed within 10 minutes
+      const renames = messages.filter(
+        (m) =>
+          m.author.id === channel.ownerId &&
+          m.type === MessageType.ChannelNameChange
       )
-      if (minutesSinceLastRename < 10) {
-        embed.setDescription(
-          `You can only rename a thread once every 10 minutes.`
+      const lastRenameTimestamp = renames.first()?.createdTimestamp
+      if (lastRenameTimestamp) {
+        const minutesSinceLastRename = Math.floor(
+          (Date.now() - lastRenameTimestamp) / 1000 / 60
         )
+        if (minutesSinceLastRename < 10) {
+          embed.setDescription(
+            `You can only rename a thread once every 10 minutes.`
+          )
+          return { embeds: [embed], ephemeral: true }
+        }
+      }
+      const title = interaction.options.getString('title', true)
+      const name = `${parseTitlePrefix(channel.name) || ''}${title.slice(
+        0,
+        90
+      )}`
+      if (await channel.setName(name)) {
+        try {
+          await prisma.question.update({
+            where: { threadId: channel.id },
+            data: { title },
+          })
+        } catch (error) {
+          console.error('Unable to update thread name in db', error)
+        }
+
+        embed.setDescription(`This thread has been renamed.`)
         return { embeds: [embed], ephemeral: true }
       }
+      break
     }
-
-    // rename the thread
-    const [{ value: title }] = args.rename.options
-    const name = `${parseTitlePrefix(channel.name) || ''}${title.slice(0, 90)}`
-    if (await channel.setName(name)) {
-      try {
-        await prisma.question.update({
-          where: { threadId: channel.id },
-          data: { title },
-        })
-      } catch (error) {
-        console.error('Unable to update thread name in db', error)
+    case 'solved': {
+      // is the channel already marked as solved?
+      const prefix = parseTitlePrefix(channel.name)
+      if (prefix === PREFIXES.solved) {
+        embed.setDescription('Thread is already marked as solved.')
+        return { embeds: [embed] }
       }
 
-      embed.setDescription(`This thread has been renamed.`)
-      return { embeds: [embed], ephemeral: true }
+      // mark the thread as solved
+      const title = parseTitle(channel.name)
+      if (await channel.setName(`${PREFIXES.solved}${title}`)) {
+        try {
+          await prisma.question.update({
+            where: { threadId: channel.id },
+            data: { isSolved: true },
+          })
+          embed.setDescription('Marked as solved.')
+        } catch (error) {
+          console.error('Unable to update thread isSolved=true in db', error)
+          embed.setDescription(
+            'Something went wrong updating the question on our end.'
+          )
+        }
+
+        return { embeds: [embed] }
+      }
+      break
     }
-  }
-
-  /**
-   * @TODO reenable after implementing command hooks (needs to message back, THEN archive)
-   */
-  // if (args.archive) {
-  //   // send a message
-  //   const embed = new EmbedBuilder()
-  //   embed.setColor('#ff9900')
-  //   embed.setDescription('This thread has been archived.')
-  //   channel.send({ embeds: [embed] })
-
-  //   // archive thread
-  //   let reason
-  //   if (args.archive.options.length) {
-  //     reason = args.archive.options[0].value
-  //   }
-  //   await channel.setArchived(true, reason)
-  //   return
-  // }
-
-  if (args.solved) {
-    const embed = new EmbedBuilder()
-    embed.setColor('#ff9900')
-
-    // is the channel already marked as solved?
-    const prefix = parseTitlePrefix(channel.name)
-    if (prefix === PREFIXES.solved) {
-      embed.setDescription('Thread is already marked as solved.')
-      return { embeds: [embed] }
-    }
-
-    // mark the thread as solved
-    const title = parseTitle(channel.name)
-    if (await channel.setName(`${PREFIXES.solved}${title}`)) {
-      let updated = false
-      try {
-        await prisma.question.update({
-          where: { threadId: channel.id },
-          data: { isSolved: true },
-        })
-        updated = true
-      } catch (error) {
-        console.error('Unable to update thread isSolved=true in db', error)
+    case 'reopen': {
+      // is the channel already marked as solved?
+      const prefix = parseTitlePrefix(channel.name)
+      if (prefix === PREFIXES.open) {
         embed.setDescription(
-          'Something went wrong updating the question on our end.'
+          'Thread has not yet been marked as solved, skipping..'
         )
+        return { embeds: [embed] }
       }
 
-      if (updated) embed.setDescription('Marked as solved.')
-      return { embeds: [embed] }
-    }
-  }
+      // mark the thread as solved
+      const title = parseTitle(channel.name)
+      if (await channel.setName(`${PREFIXES.open}${title}`)) {
+        try {
+          await prisma.question.update({
+            where: { threadId: channel.id },
+            data: { isSolved: false },
+          })
+        } catch (error) {
+          console.error('Unable to update thread isSolved=false in db', error)
+        }
 
-  if (args.reopen) {
-    const embed = new EmbedBuilder()
-    embed.setColor('#ff9900')
-
-    // is the channel already marked as solved?
-    const prefix = parseTitlePrefix(channel.name)
-    if (prefix === PREFIXES.open) {
-      embed.setDescription(
-        'Thread has not yet been marked as solved, skipping..'
-      )
-      return { embeds: [embed] }
-    }
-
-    // mark the thread as solved
-    const title = parseTitle(channel.name)
-    if (await channel.setName(`${PREFIXES.open}${title}`)) {
-      try {
-        await prisma.question.update({
-          where: { threadId: channel.id },
-          data: { isSolved: false },
-        })
-      } catch (error) {
-        console.error('Unable to update thread isSolved=false in db', error)
+        embed.setDescription('Thread has been re-opened.')
+        return { embeds: [embed] }
       }
-
-      embed.setDescription('Thread has been re-opened.')
-      return { embeds: [embed] }
+      break
     }
+    default:
+      break
   }
 
   return '🤢 something went wrong'
@@ -219,14 +188,3 @@ export const config = new SlashCommandBuilder()
   .addSubcommand((subcommand) =>
     subcommand.setName('reopen').setDescription('Reopen this thread')
   )
-// .addSubcommand((subcommand) =>
-//   subcommand
-//     .setName('archive')
-//     .setDescription('Archive this thread')
-//     .addStringOption((option) =>
-//       option
-//         .setName('reason')
-//         .setDescription('Reason for archiving this thread')
-//         .setRequired(false)
-//     )
-// )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

migrates `/thread` command handler to get the subcommand and use a switch statement on the subcommand


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
