### PR TITLE
feat(actions): add reusable actions, release cleanup

### DIFF
--- a/.github/actions/cleanup-discarded-release/action.yaml
+++ b/.github/actions/cleanup-discarded-release/action.yaml
@@ -1,0 +1,29 @@
+# used to extract the version from a release branch
+# "release/1.0.0-next.0" -> "1.0.0-next.0"
+name: cleanup-discarded-release
+description: Cleans up discarded release artifacts such as branch and draft release
+inputs:
+  github-token:
+    description: GitHub token needed for ops
+    default: ${{ github.token }}
+    required: true
+  version:
+    description: version of the discarded release (e.g. v1.0.0-next.0)
+    required: true
+  branch:
+    description: branch name (e.g. head_ref)
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: true
+    - name: delete-release-branch
+      run: git push origin --quiet --delete ${{ inputs.branch }} && echo 'deleted branch' || true
+      shell: bash
+    - name: delete-release-draft
+      run: gh release delete ${{ inputs.version }} && echo 'deleted release' || true
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/extract-version-from-branch/action.yaml
+++ b/.github/actions/extract-version-from-branch/action.yaml
@@ -1,0 +1,22 @@
+# used to extract the version from a release branch
+# "release/1.0.0-next.0" -> "1.0.0-next.0"
+name: extract-version-from-branch
+description: Extracts version from a branch name
+inputs:
+  branch:
+    description: branch name (e.g. head_ref)
+    required: true
+outputs:
+  version:
+    description: extracted version
+    value: ${{ steps.version.outputs.result }}
+runs:
+  using: 'composite'
+  steps:
+    - name: extract-version
+      id: version
+      shell: bash
+      run: |
+        branch=${{ inputs.branch }}
+        version=${branch#release/}
+        echo "version=$version" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           persist-credentials: false
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/cleanup-discarded-release.yaml
+++ b/.github/workflows/cleanup-discarded-release.yaml
@@ -1,0 +1,26 @@
+name: cleanup-discarded-release
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - id: version
+        uses: ./.github/actions/extract-version-from-branch
+        with:
+          branch: ${{ github.head_ref }}
+      - uses: ./.github/actions/cleanup-discarded-release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.head_ref }}
+          version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: true
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2
       - name: set git config for pnpm version, git push
         run: |
           git config --global user.name "GitHub Actions"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,6 +16,11 @@ on:
         required: true
 jobs:
   create-release:
+    permissions:
+      # needed to create release PR
+      pull-requests: write
+      # needed to create draft release
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -26,14 +31,23 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email noreply@github.com
+      - name: is-prerelease
+        id: is-prerelease
+        run: |
+          is=false
+          if [[ ${{ github.event.inputs.type }} == pre* ]]
+          then
+            is=true
+          fi
+          echo "is-prerelease=$is" >> $GITHUB_OUTPUT
       - name: set-version
         id: version
         run: |
-          if [[ ${{ github.event.inputs.type }} != pre* ]]
+          if [[ ${{ steps.is-prerelease.outputs.is-prerelease }} == true ]]
           then
-            version=$(pnpm version ${{ github.event.inputs.type }} --no-git-tag-version)
+            version=$(pnpm version ${{ github.event.inputs.type }} --no-git-tag-version --preid next)
           else
-            version=$(pnpm version ${{ github.event.inputs.type }} --preid next --no-git-tag-version)
+            version=$(pnpm version ${{ github.event.inputs.type }}  --no-git-tag-version)
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - run: echo "::debug::version is ${{ steps.version.outputs.version }}"
@@ -46,21 +60,51 @@ jobs:
       #     cache: 'pnpm'
       - id: branch
         run: echo "name=release/${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
-      - name: Create release branch
+      - name: create release branch
         run: git checkout -b ${{ steps.branch.outputs.name }}
       # this is not required when pnpm is creating the git tag
-      - name: add and commit changes
+      - name: add and commit changes to release branch
         run: |
           git add package.json
           git commit -m '[automated] release: ${{ steps.version.outputs.version }}'
-      - run: git push origin ${{ steps.branch.outputs.name }}
-      - id: pr
+      - name: push to release branch
+        run: git push origin ${{ steps.branch.outputs.name }}
+      - name: create draft release
+        id: draft-release
         run: |
-          url=$(gh pr create --title "release: ${{ steps.version.outputs.version }}" --body "Automated PR created to release a new version of the project")
-          echo "link=$url" >> $GITHUB_OUTPUT
-
+          if [[ ${{ steps.is-prerelease.outputs.is-prerelease }} == true ]]
+          then
+            url=$(gh release create ${{ steps.version.outputs.version }} --generate-notes --draft --prerelease)
+          else
+            url=$(gh release create ${{ steps.version.outputs.version }} --generate-notes --draft)
+          fi
+          echo "url=$url" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: echo '${{ steps.pr.outputs.link }}'
+      # TODO: remove sleep https://github.com/cli/cli/issues/6599#issuecomment-1314562972
+      - run: sleep 5
+      - name: create pull request
+        id: pr
+        run: |
+          body_file=body.md
+          # get URL to this workflow run
+          run="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # output intro message to an ephemeral markdown file
+          echo "_This pull request was automatically created by [GitHub Actions]($run)_" > $body_file
+          # output the generated release notes to an ephemeral markdown file
+          gh release view ${{ steps.version.outputs.version }} --json body --jq .body >> $body_file
+          # get the pull request URL
+          url=$(gh pr create --title "release: ${{ steps.version.outputs.version }}" --body-file $body_file)
+          echo "link=$url" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: echo ::notice title="created"::${{ steps.pr.outputs.link }}
       - run: echo ::notice title="type"::${{ github.event.inputs.type }}
+      - run: echo ::notice title="draft release"::${{ steps.draft-release.outputs.url }}
+      - name: cleanup
+        if: failure()
+        uses: ./.github/actions/cleanup-discarded-release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.branch.outputs.name }}
+          version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/release-env.yml
+++ b/.github/workflows/release-env.yml
@@ -33,7 +33,7 @@ jobs:
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ inputs.aws-region }}
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,10 @@ jobs:
       version: ${{ steps.version.outputs.result }}
       is-prerelease: ${{ contains(steps.version.outputs.result, 'next') }}
     steps:
-      - name: extract-version
-        id: version
-        uses: actions/github-script@0.2.0
+      - id: version
+        uses: ./.github/actions/extract-version-from-branch
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            return context.payload.pull_request.title.replace(/release\: /, '');
+          branch: ${{ github.head_ref }}
   prerelease:
     needs: verify-run
     uses: ./.github/workflows/release-env.yml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- adds composite actions:
	- `cleanup-discarded-release` cleans up discarded release artifacts such as branches and draft releases
	- `extract-version-from-branch` extracts a version from a branch name (e.g. `release/v1.0.0` -> `v1.0.0`)
- adds `cleanup-discarded-release` workflow to trigger composite action
- modifies `create-release` workflow to:
	- create the draft release in GitHub 
	- post the release notes in the PR
	- run a cleanup job on failure (if a failure were to occur -- not likely)
- modifies release workflow to use composite action `extract-version-from-branch`

TODO: migrate all workflows to use `.yaml`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
