### PR TITLE
fix(app): hide github link

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -88,13 +88,13 @@
                 <HeaderPanelLink href="/admin">Admin</HeaderPanelLink>
               {/if}
               <HeaderPanelLink href="/logout">Logout</HeaderPanelLink>
-              {#if !$session.user.github}
+              <!-- {#if !$session.user.github}
                 <HeaderPanelLink href="/profile/link"
                   >Link GitHub Account</HeaderPanelLink
                 >
               {:else}
                 <p class="header-text">Github Account Linked</p>
-              {/if}
+              {/if} -->
             </HeaderPanelLinks>
           </HeaderAction>
         {:else}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

hides "Link your GitHub Account" link in the profile panel ahead of launching the GitHub App


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
