### PR TITLE
add filters and sorting to questions page

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "discord.js": "^14.4.0",
     "express": "^4.18.1",
     "fast-glob": "^3.2.11",
-    "fuzzy": "^0.1.3",
     "next-auth": "^4.10.3",
     "prisma": "^4.5.0",
     "svelte": "3.49.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,6 @@ importers:
       eslint-plugin-svelte3: ^4.0.0
       express: ^4.18.1
       fast-glob: ^3.2.11
-      fuzzy: ^0.1.3
       jsdom: ^20.0.0
       lint-staged: ^13.0.3
       next-auth: ^4.10.3
@@ -83,7 +82,6 @@ importers:
       discord.js: 14.4.0
       express: 4.18.1
       fast-glob: 3.2.11
-      fuzzy: 0.1.3
       next-auth: 4.10.3
       prisma: 4.5.0
       svelte: 3.49.0
@@ -4183,11 +4181,6 @@ packages:
   /functional-red-black-tree/1.0.1:
     resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
     dev: true
-
-  /fuzzy/0.1.3:
-    resolution: {integrity: sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==}
-    engines: {node: '>= 0.6.0'}
-    dev: false
 
   /get-caller-file/2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}

--- a/src/routes/questions/+page.svelte
+++ b/src/routes/questions/+page.svelte
@@ -1,27 +1,83 @@
 <script lang="ts">
-  import type { PageData } from './$types'
   import {
     Content,
+    Dropdown,
     Grid,
     Row,
     Column,
     UnorderedList,
     ListItem,
     Link,
-    Search,
+    MultiSelect,
   } from 'carbon-components-svelte'
-  import fuzzy from 'fuzzy'
   import type { Question } from '@prisma/client'
-
-  const { match } = fuzzy
+  import type { PageData } from './$types'
 
   export let data: PageData
   $: ({ questions } = data)
   let filtered: Question[] = questions
 
-  let search = ''
+  let availableChannels: string[] = []
+  $: availableChannels = Array.from(
+    new Set(questions.map(({ channelName }) => channelName))
+  )
 
-  $: filtered = questions.filter((question) => match(search, question.title))
+  $: statusFilter = ['solved', 'unsolved']
+  $: channelFilter = availableChannels
+
+  function handleFilterByStatus(event: CustomEvent) {
+    statusFilter = event.detail.selectedIds
+  }
+
+  function handleFilterByChannel(event: CustomEvent) {
+    channelFilter = event.detail.selectedIds
+  }
+
+  const sortByFields = {
+    title: (a: Question, b: Question) => a.title.localeCompare(b.title),
+    channelName: (a: Question, b: Question) =>
+      a.channelName.localeCompare(b.channelName),
+    isSolved: (a: Question, b: Question) => (a.isSolved > b.isSolved ? 1 : -1),
+  }
+
+  let selectedSortBy: keyof typeof sortByFields = 'isSolved'
+  let selectedSortDirection: 'ASC' | 'DESC' = 'ASC'
+
+  function sortBy(
+    field: keyof typeof sortByFields,
+    direction: 'ASC' | 'DESC' = 'ASC'
+  ) {
+    const sorted = filtered.sort(sortByFields[field])
+    if (direction === 'DESC') {
+      return sorted.reverse()
+    }
+    return sorted
+  }
+
+  function handleSortBy(event: CustomEvent) {
+    const field = event.detail.selectedId as keyof typeof sortByFields
+    selectedSortBy = field
+    filtered = sortBy(field, selectedSortDirection)
+  }
+
+  function handleSortDirection(event: CustomEvent) {
+    if (selectedSortDirection !== event.detail.selectedId) {
+      filtered = sortBy(selectedSortBy, event.detail.selectedId)
+    }
+    selectedSortDirection = event.detail.selectedId
+  }
+
+  $: filtered = questions
+    .filter((question) => {
+      if (
+        statusFilter.includes(question.isSolved ? 'solved' : 'unsolved') &&
+        channelFilter.includes(question.channelName)
+      ) {
+        return true
+      }
+      return false
+    })
+    .sort(sortByFields[selectedSortBy])
 </script>
 
 <svelte:head>
@@ -33,15 +89,79 @@
     <Row>
       <Column class="ha--questions">
         <h1>Discord Questions</h1>
-        <div class="ha--search-form">
-          <Search placeholder="{'Search questions'}" bind:value="{search}" />
+        <div>
+          <MultiSelect
+            titleText="Filter by status"
+            label="{statusFilter.length === 2
+              ? 'All statuses'
+              : statusFilter.length === 1
+              ? statusFilter[0] === 'solved'
+                ? 'Solved'
+                : 'Unsolved'
+              : ''}"
+            name="status"
+            items="{[
+              { id: 'solved', text: 'Solved' },
+              { id: 'unsolved', text: 'Unsolved' },
+            ]}"
+            selectedIds="{statusFilter}"
+            itemToString="{(item) => item?.text}"
+            placeholder="All statuses"
+            size="xl"
+            on:select="{handleFilterByStatus}"
+          />
+          <div id="filter-by-channel">
+            <MultiSelect
+              titleText="Filter by channel"
+              label="{channelFilter.length === availableChannels.length
+                ? 'All channels'
+                : channelFilter.length === 0
+                ? 'Filter by channel'
+                : channelFilter.join(', ')}"
+              name="channel"
+              items="{availableChannels.map((name) => ({
+                id: name,
+                text: name,
+              }))}"
+              selectedIds="{channelFilter}"
+              itemToString="{(item) => item?.text}"
+              placeholder="All channels"
+              size="xl"
+              on:select="{handleFilterByChannel}"
+            />
+          </div>
+          <Dropdown
+            titleText="Sort by"
+            items="{[
+              { id: 'title', text: 'Title' },
+              { id: 'channelName', text: 'Channel' },
+              { id: 'isSolved', text: 'Status' },
+            ]}"
+            itemToString="{(item) => item?.text}"
+            placeholder="Sort by"
+            selectedId="{selectedSortBy}"
+            size="xl"
+            on:select="{handleSortBy}"
+          />
+          <Dropdown
+            titleText="Sort direction"
+            items="{[
+              { id: 'ASC', text: 'ASC' },
+              { id: 'DESC', text: 'DESC' },
+            ]}"
+            itemToString="{(item) => item?.text}"
+            placeholder="Direction"
+            selectedId="{selectedSortDirection}"
+            size="xl"
+            on:select="{handleSortDirection}"
+          />
         </div>
         <UnorderedList>
           {#each filtered as question}
             <ListItem>
-              <Link href="{`/questions/${question.id}`}"
-                >{question.isSolved ? '✅' : '﹖'} [{question.channelName}] {question.title}</Link
-              >
+              <Link href="{`/questions/${question.id}`}">
+                {question.isSolved ? '✅' : '﹖'} [{question.channelName}] {question.title}
+              </Link>
             </ListItem>
           {/each}
         </UnorderedList>
@@ -51,10 +171,10 @@
 </Content>
 
 <style>
-  :global(.ha--search-form) {
+  div {
     display: flex;
     flex-direction: row;
-
+    gap: var(--cds-spacing-03);
     position: relative;
     left: unset;
     bottom: unset;
@@ -62,16 +182,29 @@
   }
 
   @media (max-width: 33rem) {
-    :global(.ha--search-form) {
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      right: 0;
+    div {
+      flex-direction: column;
     }
   }
 
   :global(.ha--questions) {
     display: grid;
     grid-gap: var(--cds-layout-02);
+  }
+
+  #filter-by-channel {
+    flex-grow: 1;
+    /* quick hack to show a list of channels but not allow it to overflow */
+    max-width: 90vw;
+  }
+
+  @media (min-width: 33rem) {
+    #filter-by-channel {
+      max-width: 50vw;
+    }
+  }
+
+  #filter-by-channel :global(.bx--multi-select__wrapper) {
+    width: 100%;
   }
 </style>


### PR DESCRIPTION
*Issue #, if available:*

closes #372 
closes #373 

*Description of changes:*

- adds filter by question status (solved & unsolved)
- adds filter by question channel
- adds sort by title, channel name, status
- adds ASC, DESC sorting

![image](https://user-images.githubusercontent.com/5033303/220797041-3a6e98c6-90ca-4ac3-a141-ed556f5695fa.png)
![image](https://user-images.githubusercontent.com/5033303/220797085-d320cbc6-1789-4553-8e1e-d280c8bdcc89.png)

https://user-images.githubusercontent.com/5033303/220797113-e41c4e46-8c34-44a4-b4fe-cae2bad24fd3.mov




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
