### PR TITLE
add tag filter to dashboard page

### DIFF
--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -399,6 +399,11 @@ export const load: PageServerLoad = async ({
         createdAt: true,
         channelName: true,
         isSolved: true,
+        tags: {
+          select: {
+            name: true,
+          },
+        },
       },
     })
   ).map((question) => {
@@ -412,6 +417,9 @@ export const load: PageServerLoad = async ({
 
   return {
     channels: await fetchHelpChannels(guildId),
+    tags: Array.from(
+      new Set(questions.map(({ tags }) => tags.map(({ name }) => name)).flat())
+    ).sort((a, b) => a.localeCompare(b)),
     contributors: {
       all: await getAllContributors(guildId),
       staff: await getStaffContributors(guildId),

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -39,6 +39,7 @@
     memberCount,
     name,
     presenceCount,
+    tags,
     questions,
   } = data
 
@@ -47,7 +48,7 @@
   let startDate = new Date(today.getFullYear(), today.getMonth() - 3, 1)
   let dates: Date[] = timeBetweenDates('months', [startDate, endDate])
   let filteredQuestions: Map<string, Questions> =
-    filterQuestionsByChannelAndDate(channels, dates, questions)
+    filterQuestionsByChannelAndDate(questions, channels, [], dates)
   let filteredContributors: Contributor[] = filterAnswers(
     channels,
     [dates[0], today],
@@ -111,10 +112,14 @@
     return values
   }
 
+  /**
+   * filtered questions by category ("all", "unanswered", "staff", "community")
+   */
   $: filteredQuestions = filterQuestionsByChannelAndDate(
+    questions,
     channels,
-    dates,
-    questions
+    tags,
+    dates
   )
   $: filteredContributors = filterAnswers(
     channels,
@@ -189,11 +194,11 @@
         <Row>
           <Column><h1>Questions</h1></Column><Column
             ><Button
-              iconDescription="Download csv"
+              iconDescription="Download CSV"
               kind="ghost"
               icon="{DocumentDownload}"
               on:click="{() => toCSVQuestions(channels, filteredQuestions)}"
-            /></Column
+            />Download CSV</Column
           >
         </Row>
       </Column>
@@ -201,6 +206,7 @@
         <FilterMenu
           bind:dates
           bind:channels
+          bind:tags
           today="{today}"
           startDate="{startDate}"
           endDate="{endDate}"

--- a/src/routes/dashboard/components/FilterMenu.svelte
+++ b/src/routes/dashboard/components/FilterMenu.svelte
@@ -14,6 +14,7 @@
   export let startDate: Date
   export let endDate: Date
   export let channels: string[]
+  export let tags: string[]
 
   const dateOptions = {
     weekday: 'long',
@@ -21,6 +22,8 @@
     month: 'long',
     day: 'numeric',
   }
+
+  const availableTags = tags
 
   // filter by channel
   const channelDropdownItems: { id: string; text: string }[] = []
@@ -33,6 +36,7 @@
   }
 
   let channel_selectedIds = channelDropdownItems.map((item) => item.id)
+  let tag_selectedIds = tags
 
   // filter by date
   let frequency_selectedId = '2'
@@ -67,10 +71,15 @@
     dates = timeBetweenDates(frequency, d.detail.selectedDates)
   }
 
-  const getChannels = (channel_selectedIds: string[]) =>
-    channel_selectedIds.map(
+  const getChannels = (channel_selectedIds: string[]) => {
+    return channel_selectedIds.map(
       (id) => channelDropdownItems.find((item) => item.id === id)?.text
     )
+  }
+
+  const getTags = (tag_selectedIds: string[]) => {
+    return tag_selectedIds.map((id) => availableTags.find((tag) => tag === id))
+  }
 
   const frequencySpelling = () =>
     dates.length === 1 ? frequency.slice(0, -1) : frequency
@@ -82,6 +91,7 @@
     frequencyDropdownItems.find((item) => item.id === frequency_selectedId)
       ?.value ?? ''
   $: channels = getChannels(channel_selectedIds)
+  $: tags = getTags(tag_selectedIds)
   $: dates = timeBetweenDates(frequency, [startDate, endDate])
 </script>
 
@@ -115,12 +125,28 @@
     </DatePicker>
     <p>{label}</p>
   </Column>
-  <Column
-    ><MultiSelect
+  <Column>
+    <MultiSelect
       class="frequency-selector"
       items="{channelDropdownItems}"
-      titleText="Channel"
+      titleText="Filter by Channel"
       bind:selectedIds="{channel_selectedIds}"
+    />
+    <MultiSelect
+      titleText="Filter by tags"
+      label="{tag_selectedIds.length === availableTags.length
+        ? 'All tags'
+        : tag_selectedIds.length === 0
+        ? 'Filter by tags'
+        : tag_selectedIds.join(', ')}"
+      name="tags"
+      items="{availableTags.map((name) => ({
+        id: name,
+        text: name,
+      }))}"
+      bind:selectedIds="{tag_selectedIds}"
+      itemToString="{(item) => item?.text}"
+      placeholder="All tags"
     />
   </Column>
 </Row>

--- a/src/routes/dashboard/helpers/filter-questions-by-channel.ts
+++ b/src/routes/dashboard/helpers/filter-questions-by-channel.ts
@@ -1,0 +1,11 @@
+import type { Question } from '../types'
+
+/**
+ * Filters questions by channel
+ */
+export function filterQuestionsByChannel(
+  questions: Question[],
+  channels: string[]
+) {
+  return questions.filter((question) => channels.includes(question.channelName))
+}

--- a/src/routes/dashboard/helpers/filter-questions-by-date-range.ts
+++ b/src/routes/dashboard/helpers/filter-questions-by-date-range.ts
@@ -1,0 +1,17 @@
+import type { Question } from '../types'
+
+/**
+ * Filters questions by date
+ * @param questions Questions to filter
+ * @param dates Dates to filter by
+ */
+export function filterQuestionsByDateRange(
+  questions: Question[],
+  dates: Date[]
+) {
+  return questions.filter(
+    (question) =>
+      new Date(question.createdAt) >= dates[0] &&
+      new Date(question.createdAt) < dates[1]
+  )
+}

--- a/src/routes/dashboard/helpers/filter-questions-by-tag.ts
+++ b/src/routes/dashboard/helpers/filter-questions-by-tag.ts
@@ -6,7 +6,11 @@ import type { Question } from '../types'
  * @param tags tags to filter by
  */
 export function filterQuestionsByTag(questions: Question[], tags: string[]) {
-  return questions.filter((question) =>
-    tags.some((tag) => question.tags.some((t) => t.name === tag))
-  )
+  let filtered = questions
+  if (tags.length) {
+    filtered = questions.filter((question) =>
+      tags.some((tag) => question.tags?.some((t) => t.name === tag))
+    )
+  }
+  return filtered
 }

--- a/src/routes/dashboard/helpers/filter-questions-by-tag.ts
+++ b/src/routes/dashboard/helpers/filter-questions-by-tag.ts
@@ -1,0 +1,12 @@
+import type { Question } from '../types'
+
+/**
+ * Filter Questions by Forum Channel tags
+ * @param questions Questions to filter
+ * @param tags tags to filter by
+ */
+export function filterQuestionsByTag(questions: Question[], tags: string[]) {
+  return questions.filter((question) =>
+    tags.some((tag) => question.tags.some((t) => t.name === tag))
+  )
+}

--- a/src/routes/dashboard/helpers/filter-questions.ts
+++ b/src/routes/dashboard/helpers/filter-questions.ts
@@ -1,0 +1,26 @@
+import { filterQuestionsByDateRange } from './filter-questions-by-date-range'
+import { filterQuestionsByChannel } from './filter-questions-by-channel'
+import { filterQuestionsByTag } from './filter-questions-by-tag'
+import type { Question } from '../types'
+
+type FilterOptions = {
+  dates?: Date[]
+  channels?: string[]
+  tags?: string[]
+}
+
+export function filterQuestions(questions: Question[], options: FilterOptions) {
+  let filtered = questions
+
+  if (options.dates) {
+    filtered = filterQuestionsByDateRange(filtered, options.dates)
+  }
+  if (options.channels) {
+    filtered = filterQuestionsByChannel(filtered, options.channels)
+  }
+  if (options.tags) {
+    filtered = filterQuestionsByTag(filtered, options.tags)
+  }
+
+  return filtered
+}

--- a/src/routes/dashboard/types.d.ts
+++ b/src/routes/dashboard/types.d.ts
@@ -1,46 +1,53 @@
+import type { Question as PrismaQuestion, QuestionTag } from '@prisma/client'
+
 export type Questions = {
-  total: Question[],
-  unanswered: Question[],
-  staff: Question[],
-  community: Question[],
+  total: Question[]
+  unanswered: Question[]
+  staff: Question[]
+  community: Question[]
 }
 
 export type Contributors = {
-  all: Contributor[],
-  staff: Contributor[],
+  all: Contributor[]
+  staff: Contributor[]
   // community: Contributor[],
 }
 
-export type Question = {
-  channelName: string,
-  createdAt: Date,
-  id: string,
-  isSolved?: boolean
+export type Question = Pick<
+  PrismaQuestion,
+  'channelName' | 'createdAt' | 'id' | 'isSolved'
+> & {
+  tags: QuestionTag[]
 }
 
 export type Contributor = {
-  id: string,
-  githubId?: string,
-  discordUsername?: string,
+  id: string
+  githubId?: string
+  discordUsername?: string
   answers: Question[]
 }
-export type GitHubUser =  {
-  login: string,
-  id: number,
-  node_id: string,
-  avatar_url: string,
-  gravatar_id: string,
-  url: string,
-  html_url: string,
-  followers_url: string,
-  following_url: string,
-  gists_url: string,
-  starred_url: string,
-  subscriptions_url: string,
-  organizations_url: string,
-  repos_url: string,
-  events_url: string,
-  received_events_url: string,
-  type: string,
-  site_admin: boolean,
+
+/**
+ * @todo can this come from a GitHub package?
+ * @see https://www.npmjs.com/package/@octokit/types
+ */
+export type GitHubUser = {
+  login: string
+  id: number
+  node_id: string
+  avatar_url: string
+  gravatar_id: string
+  url: string
+  html_url: string
+  followers_url: string
+  following_url: string
+  gists_url: string
+  starred_url: string
+  subscriptions_url: string
+  organizations_url: string
+  repos_url: string
+  events_url: string
+  received_events_url: string
+  type: string
+  site_admin: boolean
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

enables filtering by forum channel post tags. this follows the functionality of the `/questions` page where tags are automatically filtered to _all_, and removing tag selections will return all questions without tags (i.e. those created from text channels)

![image](https://user-images.githubusercontent.com/5033303/226478831-8f55adee-ee9c-4e18-b0db-d4b689508564.png)
![image](https://user-images.githubusercontent.com/5033303/226478862-c16acf92-75f3-4233-8d53-ccf261c74bfd.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
