### PR TITLE
reorder select-answer's data operations, mitigates multiple db writes

### DIFF
--- a/src/lib/discord/commands/select-answer.ts
+++ b/src/lib/discord/commands/select-answer.ts
@@ -114,13 +114,6 @@ export const handler = async (
   const embed = new EmbedBuilder()
   embed.setColor('#ff9900')
 
-  // is the channel already marked as solved?
-  const prefix = parseTitlePrefix(channel.name)
-  if (prefix !== PREFIXES.solved) {
-    const title = parseTitle(channel.name)
-    await channel.setName(`${PREFIXES.solved}${title}`)
-  }
-
   let updated = false
   try {
     await prisma.question.update({
@@ -133,6 +126,23 @@ export const handler = async (
     embed.setDescription(
       'Something went wrong updating the question on our end.'
     )
+  }
+
+  // is the channel already marked as solved?
+  const prefix = parseTitlePrefix(channel.name)
+  if (prefix !== PREFIXES.solved) {
+    const title = parseTitle(channel.name)
+    try {
+      await channel.setName(`${PREFIXES.solved}${title}`)
+    } catch (error) {
+      console.error(
+        `Unable to update thread name for question ${record?.id}`,
+        error
+      )
+      embed.setDescription(
+        'Something went wrong updating the thread name on our end.'
+      )
+    }
   }
 
   if (updated) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

re-orders select-answers operations to update the thread title after setting it as `isSolved` in the database

there's currently an issue between `select-answer` and the `ThreadUpdate` event handler where the command changes the threads title before setting `isSolved=true` in the database. When the thread title is updated, `ThreadUpdate`'s event handler fires and the two write events are clashing:

![image](https://user-images.githubusercontent.com/5033303/227015480-2dea1750-9621-4561-8a25-4f69a0b12a43.png)
![image](https://user-images.githubusercontent.com/5033303/227015651-a1ce4ffc-74ab-44df-b63d-96c3d58a6dee.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
