### PR TITLE
fetch all thread messages during backfill

### DIFF
--- a/src/lib/discord/client.ts
+++ b/src/lib/discord/client.ts
@@ -407,6 +407,7 @@ client.on(Events.ThreadUpdate, async (oldThread, newThread) => {
     // update the participants (we do this after the question is created/updated to ensure the question exists in the database and has a valid ID to create the participation records with)
     if (record) {
       console.log('Updating participants', newThread.id)
+      const messages = await newThread.messages.fetch()
       try {
         await prisma.question.update({
           where: {
@@ -414,7 +415,7 @@ client.on(Events.ThreadUpdate, async (oldThread, newThread) => {
           },
           data: {
             participation: {
-              connectOrCreate: newThread.messages.cache.map((message) => ({
+              connectOrCreate: messages.map((message) => ({
                 where: {
                   questionId_participantId: {
                     questionId: record.id,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

modifies backfill behavior to fetch all thread messages during participation backfill to ensure we capture each message and their authors


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
