### PR TITLE
patch github auth error

### DIFF
--- a/src/lib/github/create-octokit.ts
+++ b/src/lib/github/create-octokit.ts
@@ -5,7 +5,7 @@ import { fetchGitHubToken } from './fetch-github-token'
  * Creates an Octokit instance
  */
 export async function createOctokit() {
-  const token = await fetchGitHubToken()
+  const token = (await fetchGitHubToken()).catch(console.error)
   return new Octokit({
     auth: `token ${token}`,
   })

--- a/src/lib/github/get-github-members.ts
+++ b/src/lib/github/get-github-members.ts
@@ -8,7 +8,9 @@ export async function getGitHubMembers() {
     })
     return data
   } catch (cause) {
-    throw new Error(`Unable to fetch GitHub members`, { cause })
+    // throw new Error(`Unable to fetch GitHub members`, { cause })
+    const error = new Error(`Unable to fetch GitHub members`, { cause })
+    console.error(error.message, error)
   }
   return []
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

patches behavior where a failure to get the GitHub auth token (in the event the env var is not set or is invalid) takes down the dashboard page 
![image](https://user-images.githubusercontent.com/5033303/229863326-1423e518-4abb-4f76-ac37-0962bdc48b5b.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
