### PR TITLE
add "select all" button to dashboard dropdown filters

### DIFF
--- a/src/routes/dashboard/QuestionFilterMenu.svelte
+++ b/src/routes/dashboard/QuestionFilterMenu.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    Button,
     Column,
     DatePicker,
     DatePickerInput,
@@ -78,6 +79,14 @@
     dates = timeBetweenDates(timePeriod, event.detail.selectedDates)
   }
 
+  function handleSelectAllChannels() {
+    selectedChannelIds = channelDropdownItems.map((item) => item.id)
+  }
+
+  function handleSelectAllTags() {
+    selectedTagIds = [...availableTags]
+  }
+
   function getTagLabel(availableTags: string[], selectedTags: string[]) {
     if (availableTags.length === 0) {
       return 'No tags available'
@@ -150,27 +159,51 @@
         <span class="bx--form__helper-text">{dateLabel}</span>
       </div>
 
-      <MultiSelect
-        class="frequency-selector"
-        items="{channelDropdownItems}"
-        label="{channelLabel}"
-        placeholder="All channels"
-        titleText="Filter by Channel"
-        bind:selectedIds="{selectedChannelIds}"
-      />
+      <div class="ha--filter-dropdown-container">
+        <MultiSelect
+          class="frequency-selector"
+          items="{channelDropdownItems}"
+          label="{channelLabel}"
+          placeholder="All channels"
+          titleText="Filter by Channel"
+          bind:selectedIds="{selectedChannelIds}"
+        />
+        <div>
+          <Button
+            kind="secondary"
+            size="field"
+            disabled="{selectedChannelIds.length === availableChannels.length}"
+            on:click="{handleSelectAllChannels}"
+          >
+            Select all
+          </Button>
+        </div>
+      </div>
 
-      <MultiSelect
-        titleText="Filter by tags"
-        label="{tagLabel}"
-        name="tags"
-        items="{availableTags.map((name) => ({
-          id: name,
-          text: name,
-        }))}"
-        bind:selectedIds="{selectedTagIds}"
-        itemToString="{(item) => item?.text}"
-        placeholder="All tags"
-      />
+      <div class="ha--filter-dropdown-container">
+        <MultiSelect
+          titleText="Filter by tags"
+          label="{tagLabel}"
+          name="tags"
+          items="{availableTags.map((name) => ({
+            id: name,
+            text: name,
+          }))}"
+          bind:selectedIds="{selectedTagIds}"
+          itemToString="{(item) => item?.text}"
+          placeholder="All tags"
+        />
+        <div>
+          <Button
+            kind="secondary"
+            size="field"
+            disabled="{selectedTagIds.length === availableTags.length}"
+            on:click="{handleSelectAllTags}"
+          >
+            Select all
+          </Button>
+        </div>
+      </div>
     </section>
   </Column>
 </Row>
@@ -183,6 +216,17 @@
   :global(.frequency-selector
       .bx--list-box__menu-item, .bx--list-box__menu-item__option) {
     height: auto;
+  }
+
+  .ha--filter-dropdown-container {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: end;
+  }
+
+  .ha--filter-dropdown-container :global(.bx--list-box__label) {
+    /* prevent span from causing overflow */
+    max-width: 200px;
   }
 
   p {
@@ -198,7 +242,7 @@
 
   @media (min-width: 640px) {
     section {
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: 50% 50%;
     }
   }
 </style>

--- a/src/routes/dashboard/QuestionFilterMenu.svelte
+++ b/src/routes/dashboard/QuestionFilterMenu.svelte
@@ -20,8 +20,8 @@
   export let tags: string[]
   export let timePeriod: TimePeriod = TIME_PERIODS.MONTH
 
-  const availableTags = tags
-  const availableChannels = channels
+  const availableTags = [...tags]
+  const availableChannels = [...channels]
 
   // construct channel dropdown items
   const channelDropdownItems = channels.map((channel, idx) => ({
@@ -124,7 +124,7 @@
 
   $: dateLabel = getDateLabel()
   $: tagLabel = getTagLabel(availableTags, selectedTagIds)
-  $: channelLabel = getChannelLabel(channels, selectedChannelIds)
+  $: channelLabel = getChannelLabel(availableChannels, selectedChannelIds)
 </script>
 
 <Row padding>


### PR DESCRIPTION
*Issue #, if available:*

#441 

*Description of changes:*

![image](https://user-images.githubusercontent.com/5033303/233728353-ef75fba7-cd53-49a8-8b0c-78cce911034f.png)
![image](https://user-images.githubusercontent.com/5033303/233728396-4169308f-6a3e-4286-b7e5-38803561a1c6.png)

- adds "select all" button to dashboard dropdown filters
- fixes issue with label overflow when selecting multiple filters 
![image](https://user-images.githubusercontent.com/5033303/233728570-1d5a5a79-b0e4-4cb5-ab8c-6ccf8accdd67.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
