### PR TITLE
fix dashboard health table highlighting on state change

### DIFF
--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -295,7 +295,7 @@
       <Row padding>
         <Column>
           <ChannelHealthTable
-            bind:questions="{filteredQuestions}"
+            questions="{filteredQuestions}"
             allHelpChannels="{allHelpChannels}"
           />
         </Column>
@@ -303,7 +303,7 @@
       <!-- tag health -->
       <Row padding>
         <Column>
-          <ForumChannelTagHealthTable bind:questions="{filteredQuestions}" />
+          <ForumChannelTagHealthTable questions="{filteredQuestions}" />
         </Column>
       </Row>
       <section aria-label="Top Contributors">

--- a/src/routes/dashboard/ChannelHealthTable.svelte
+++ b/src/routes/dashboard/ChannelHealthTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { DataTable } from 'carbon-components-svelte'
+  import { browser } from '$app/environment'
   import { groupQuestions } from './helpers/group-questions'
   import { getPercentageOfQuestionsSolved } from './helpers/get-percentage-of-questions-solved'
   import { filterQuestions } from './helpers/filter-questions'
@@ -40,7 +41,7 @@
 
   const title = 'Channel health'
 
-  onMount(() => {
+  function setHealthRowColor() {
     for (const row of rows) {
       const element = document.querySelector(`tr[data-row="${row.channel}"]`)
       if (!element) continue
@@ -52,7 +53,13 @@
         element.setAttribute('data-health', 'good')
       }
     }
+  }
+
+  onMount(() => {
+    setHealthRowColor()
   })
+
+  $: if (rows.length && browser) setHealthRowColor()
 </script>
 
 <section aria-label="{title}">

--- a/src/routes/dashboard/ChannelHealthTable.svelte
+++ b/src/routes/dashboard/ChannelHealthTable.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
   import { DataTable } from 'carbon-components-svelte'
-  import { browser } from '$app/environment'
+  import { getHealth } from './helpers/get-health'
   import { groupQuestions } from './helpers/group-questions'
   import { getPercentageOfQuestionsSolved } from './helpers/get-percentage-of-questions-solved'
   import { filterQuestions } from './helpers/filter-questions'
@@ -40,26 +39,6 @@
     })
 
   const title = 'Channel health'
-
-  function setHealthRowColor() {
-    for (const row of rows) {
-      const element = document.querySelector(`tr[data-row="${row.channel}"]`)
-      if (!element) continue
-      if (row.percentage < 50) {
-        element.setAttribute('data-health', 'low')
-      } else if (row.percentage < 75) {
-        element.setAttribute('data-health', 'okay')
-      } else {
-        element.setAttribute('data-health', 'good')
-      }
-    }
-  }
-
-  onMount(() => {
-    setHealthRowColor()
-  })
-
-  $: if (rows.length && browser) setHealthRowColor()
 </script>
 
 <section aria-label="{title}">
@@ -78,6 +57,13 @@
     sortable
     size="tall"
   >
+    <svelte:fragment slot="cell" let:cell let:row>
+      {#if cell.key === 'answered'}
+        <span data-health="{getHealth(cell.value)}">{cell.value}</span>
+      {:else}
+        <span>{cell.value}</span>
+      {/if}
+    </svelte:fragment>
     <svelte:fragment slot="expanded-row" let:row>
       <div class="ha-channel-health--expanded-container">
         <DataTable
@@ -113,15 +99,15 @@
 </section>
 
 <style>
-  section :global([data-health='low'] td:nth-child(3)) {
+  section :global(td:has([data-health='low'])) {
     background-color: var(--ha-health-low);
   }
 
-  section :global([data-health='okay'] td:nth-child(3)) {
+  section :global(td:has([data-health='okay'])) {
     background-color: var(--ha-health-okay);
   }
 
-  section :global([data-health='good'] td:nth-child(3)) {
+  section :global(td:has([data-health='good'])) {
     background-color: var(--ha-health-good);
   }
 

--- a/src/routes/dashboard/ForumChannelTagHealthTable.svelte
+++ b/src/routes/dashboard/ForumChannelTagHealthTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { DataTable } from 'carbon-components-svelte'
+  import { browser } from '$app/environment'
   import { groupQuestions } from './helpers/group-questions'
   import { getPercentageOfQuestionsSolved } from './helpers/get-percentage-of-questions-solved'
   import { filterQuestions } from './helpers/filter-questions'
@@ -40,7 +41,7 @@
 
   const title = 'Tag health'
 
-  onMount(() => {
+  function setHealthRowColor() {
     for (const row of rows) {
       const element = document.querySelector(`tr[data-row="${row.tag}"]`)
       if (!element) continue
@@ -52,7 +53,13 @@
         element.setAttribute('data-health', 'good')
       }
     }
+  }
+
+  onMount(() => {
+    setHealthRowColor()
   })
+
+  $: if (rows.length && browser) setHealthRowColor()
 </script>
 
 <section aria-label="{title}">

--- a/src/routes/dashboard/ForumChannelTagHealthTable.svelte
+++ b/src/routes/dashboard/ForumChannelTagHealthTable.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
   import { DataTable } from 'carbon-components-svelte'
-  import { browser } from '$app/environment'
+  import { getHealth } from './helpers/get-health'
   import { groupQuestions } from './helpers/group-questions'
   import { getPercentageOfQuestionsSolved } from './helpers/get-percentage-of-questions-solved'
   import { filterQuestions } from './helpers/filter-questions'
@@ -40,26 +39,6 @@
     })
 
   const title = 'Tag health'
-
-  function setHealthRowColor() {
-    for (const row of rows) {
-      const element = document.querySelector(`tr[data-row="${row.tag}"]`)
-      if (!element) continue
-      if (row.percentage < 50) {
-        element.setAttribute('data-health', 'low')
-      } else if (row.percentage < 75) {
-        element.setAttribute('data-health', 'okay')
-      } else {
-        element.setAttribute('data-health', 'good')
-      }
-    }
-  }
-
-  onMount(() => {
-    setHealthRowColor()
-  })
-
-  $: if (rows.length && browser) setHealthRowColor()
 </script>
 
 <section aria-label="{title}">
@@ -78,6 +57,13 @@
     sortable
     size="tall"
   >
+    <svelte:fragment slot="cell" let:cell let:row>
+      {#if cell.key === 'answered'}
+        <span data-health="{getHealth(cell.value)}">{cell.value}</span>
+      {:else}
+        <span>{cell.value}</span>
+      {/if}
+    </svelte:fragment>
     <svelte:fragment slot="expanded-row" let:row>
       <div class="ha-tag-health--expanded-container">
         <DataTable
@@ -113,15 +99,15 @@
 </section>
 
 <style>
-  section :global([data-health='low'] td:nth-child(3)) {
+  section :global(td:has([data-health='low'])) {
     background-color: var(--ha-health-low);
   }
 
-  section :global([data-health='okay'] td:nth-child(3)) {
+  section :global(td:has([data-health='okay'])) {
     background-color: var(--ha-health-okay);
   }
 
-  section :global([data-health='good'] td:nth-child(3)) {
+  section :global(td:has([data-health='good'])) {
     background-color: var(--ha-health-good);
   }
 

--- a/src/routes/dashboard/constants.ts
+++ b/src/routes/dashboard/constants.ts
@@ -11,3 +11,9 @@ export const TIME_PERIODS = {
   MONTH: 'month',
   YEAR: 'year',
 } as const
+
+export const HEALTH_STATUS = {
+  LOW: 'low',
+  OKAY: 'okay',
+  GOOD: 'good',
+} as const

--- a/src/routes/dashboard/helpers/get-health.ts
+++ b/src/routes/dashboard/helpers/get-health.ts
@@ -1,0 +1,12 @@
+/**
+ * Get health status based on percentage
+ */
+export function getHealth(percentage: number) {
+  if (percentage < 50) {
+    return 'low'
+  } else if (percentage < 75) {
+    return 'okay'
+  } else {
+    return 'good'
+  }
+}

--- a/src/routes/dashboard/types.d.ts
+++ b/src/routes/dashboard/types.d.ts
@@ -1,4 +1,4 @@
-import { TIME_PERIODS } from './constants'
+import { TIME_PERIODS, HEALTH_STATUS } from './constants'
 import type {
   Answer as PrismaAnswer,
   Question as PrismaQuestion,
@@ -7,6 +7,7 @@ import type {
 } from '@prisma/client'
 
 export type TimePeriod = ValueOf<typeof TIME_PERIODS>
+export type HealthStatus = ValueOf<typeof HEALTH_STATUS>
 
 export type Questions = {
   total: Question[]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

fixed an issue where changes made to the filters on the dashboard page will display new rows on the table without health highlighting

![image](https://user-images.githubusercontent.com/5033303/233749213-c722f934-427d-47b5-b691-b208dcded89c.png)
![image](https://user-images.githubusercontent.com/5033303/233750314-32e974af-533d-4ec7-8610-80c88638d69c.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
