### PR TITLE
fix dashboard time period dropdown's "day" value to use TIME_PERIOD constant

### DIFF
--- a/src/routes/dashboard/QuestionFilterMenu.svelte
+++ b/src/routes/dashboard/QuestionFilterMenu.svelte
@@ -31,7 +31,13 @@
 
   // construct frequency (time period) items
   const frequencyDropdownItems = [
-    { id: 0, text: 'Daily', disabled: false, value: 'days', description: '' },
+    {
+      id: 0,
+      text: 'Daily',
+      disabled: false,
+      value: TIME_PERIODS.DAY,
+      description: '',
+    },
     {
       id: 1,
       text: 'Weekly',


### PR DESCRIPTION
fixes an issue where the frontend will error upon selecting "days"