### PR TITLE
hotfix dashboard health display, use percentage number

### DIFF
--- a/src/routes/dashboard/ChannelHealthTable.svelte
+++ b/src/routes/dashboard/ChannelHealthTable.svelte
@@ -59,7 +59,7 @@
   >
     <svelte:fragment slot="cell" let:cell let:row>
       {#if cell.key === 'answered'}
-        <span data-health="{getHealth(cell.value)}">{cell.value}</span>
+        <span data-health="{getHealth(row.percentage)}">{cell.value}</span>
       {:else}
         <span>{cell.value}</span>
       {/if}

--- a/src/routes/dashboard/ForumChannelTagHealthTable.svelte
+++ b/src/routes/dashboard/ForumChannelTagHealthTable.svelte
@@ -59,7 +59,7 @@
   >
     <svelte:fragment slot="cell" let:cell let:row>
       {#if cell.key === 'answered'}
-        <span data-health="{getHealth(cell.value)}">{cell.value}</span>
+        <span data-health="{getHealth(row.percentage)}">{cell.value}</span>
       {:else}
         <span>{cell.value}</span>
       {/if}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

fixes dashboard health highlight display. health was being calculated based off the percentage string (e.g. `"75%"`) rather than the percentage number (`75`)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
