### PR TITLE
feat: check thread name length before attempting to prepend

### DIFF
--- a/src/lib/discord/commands/select-answer.ts
+++ b/src/lib/discord/commands/select-answer.ts
@@ -6,7 +6,7 @@ import type {
   GuildMember,
   MessageContextMenuCommandInteraction,
 } from 'discord.js'
-import { parseTitle, parseTitlePrefix, PREFIXES } from './thread'
+import { parseTitle, parseTitlePrefix, fitsPrefix, truncateSuffix, PREFIXES } from './thread'
 
 export const config = new ContextMenuCommandBuilder()
   .setName('select-answer')
@@ -131,7 +131,8 @@ export const handler = async (
   // is the channel already marked as solved?
   const prefix = parseTitlePrefix(channel.name)
   if (prefix !== PREFIXES.solved) {
-    const title = parseTitle(channel.name)
+    let title = parseTitle(channel.name)
+    title = fitsPrefix(title, PREFIXES.solved) ? title : truncateSuffix(title, PREFIXES.solved)
     try {
       await channel.setName(`${PREFIXES.solved}${title}`)
     } catch (error) {

--- a/src/lib/discord/commands/thread.ts
+++ b/src/lib/discord/commands/thread.ts
@@ -30,6 +30,17 @@ export function parseTitle(title: string) {
   return title.replace(parseTitlePrefix(title) as string, '')
 }
 
+export function truncateSuffix(title: string, newPrefix: string) {
+  const ellipsis = '...'
+  const trimLength = newPrefix.length + ellipsis.length
+  return title.slice(0, -trimLength) + ellipsis
+}
+
+export function fitsPrefix(title: string, prefix: string) {
+  const maxTitleLength = 100
+  return title.length <= maxTitleLength - prefix.length
+}
+
 export async function handler(
   interaction: ChatInputCommandInteraction
 ): Promise<InteractionReplyOptions | string> {
@@ -115,7 +126,9 @@ export async function handler(
       }
 
       // mark the thread as solved
-      const title = parseTitle(channel.name)
+      let title = parseTitle(channel.name)
+      title = fitsPrefix(title, PREFIXES.solved) ? title : truncateSuffix(title, PREFIXES.solved)
+
       if (await channel.setName(`${PREFIXES.solved}${title}`)) {
         try {
           await prisma.question.update({


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/discord-bot/issues/368

*Description of changes:*
When doing a `/thread solved` or selecting an answer, hey-amplify will attempt to prepend `✅ - ` to the thread name. This fails with an unhelpful error message if the thread name goes over the (current) 100 character limit imposed by Discord.

<img width="296" alt="Screenshot 2023-05-24 at 12 22 08 PM" src="https://github.com/aws-amplify/discord-bot/assets/52051793/0a0490c7-66df-4265-a2e1-bac98f29261a">


This change checks the name length before prepending the solved prefix. If it will go over that limit, it removes a few characters from the suffix and adds `...` to make room for the solved prefix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
