### PR TITLE
ci to run test npm script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       # build ./packages/*
       - run: pnpm build:lib
       # build SvelteKit app and Server
-      - run: pnpm build --logLevel silent
+      - run: pnpm build
         env:
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           VITE_HOST: ${{ secrets.VITE_HOST }}
@@ -67,7 +67,7 @@ jobs:
       - run: pnpm prisma db push
         env:
           DATABASE_URL: 'file:data/test.db'
-      - run: pnpm vitest run --silent
+      - run: pnpm test
         env:
           DISCORD_WEBHOOK_URL_RELEASES: ${{ secrets.DISCORD_WEBHOOK_URL_RELEASES }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "setup-dev": "pnpm install && prisma db push && svelte-kit sync && pnpm build:lib",
     "setup-docker": "echo \"\nPNPM_STORE\"=$(pnpm store path) >> .env && docker -v",
     "setup-test": "DATABASE_URL=\"file:data/test.db\" prisma db push && vite build",
-    "test": "vitest",
+    "test": "vitest run",
     "coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "setup-dev": "pnpm install && prisma db push && svelte-kit sync && pnpm build:lib",
     "setup-docker": "echo \"\nPNPM_STORE\"=$(pnpm store path) >> .env && docker -v",
     "setup-test": "DATABASE_URL=\"file:data/test.db\" prisma db push && vite build",
-    "test": "vitest run",
+    "test": "vitest",
     "coverage": "vitest run --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

this is mostly to prepare for the introduction of Playwright for browser testing

- changes ci action to run `pnpm test`
- removes silent logging
- note: when `CI=true`, running `vitest` is the same as running `vitest run` locally. it will run and exit


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
