### PR TITLE
container uses NEXTAUTH_URL env var

### DIFF
--- a/cdk/src/components/hey-amplify-app.ts
+++ b/cdk/src/components/hey-amplify-app.ts
@@ -105,6 +105,7 @@ export class HeyAmplifyApp extends Construct {
             environment: {
               ...docker.environment,
               BUCKET_NAME: bucket.bucketName,
+              NEXTAUTH_URL: docker.environment?.VITE_NEXTAUTH_URL || '',
               DATABASE_FILE_PATH: docker.environment!.DATABASE_URL.replace(
                 'file:',
                 ''


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Container is currently using `VITE_NEXTAUTH_URL` to replace in client code at buildtime, however there appears to be an issue at runtime where it is reading from the load balancer's address. This PR aims to resolve this issue by setting a NEXTAUTH_URL env var at runtime.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
