### PR TITLE
add rules to block requests for .sql, wp-*, etc.

### DIFF
--- a/cdk/src/components/waf.ts
+++ b/cdk/src/components/waf.ts
@@ -29,24 +29,24 @@ export class WAF extends wafv2.CfnWebACL {
       scope: wafScope || 'CLOUDFRONT',
       name,
       rules: [
-        // {
-        //   name: 'AWS-AWSManagedRulesCommonRuleSet',
-        //   priority: 1,
-        //   overrideAction: {
-        //     none: {},
-        //   },
-        //   statement: {
-        //     managedRuleGroupStatement: {
-        //       name: 'AWSManagedRulesCommonRuleSet',
-        //       vendorName: 'AWS',
-        //     },
-        //   },
-        //   visibilityConfig: {
-        //     cloudWatchMetricsEnabled: true,
-        //     metricName: 'common',
-        //     sampledRequestsEnabled: true,
-        //   },
-        // },
+        {
+          name: 'Common',
+          priority: 0,
+          statement: {
+            managedRuleGroupStatement: {
+              name: 'AWSManagedRulesCommonRuleSet',
+              vendorName: 'AWS',
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'MetricForWaf-Common',
+            sampledRequestsEnabled: true,
+          },
+          overrideAction: {
+            none: {},
+          },
+        },
         {
           // rate-limit requests
           name: 'RateLimit',
@@ -56,30 +56,169 @@ export class WAF extends wafv2.CfnWebACL {
           },
           statement: {
             rateBasedStatement: {
-              limit: 1000, // per 5 minutes
+              limit: 500, // per 5 minutes
               aggregateKeyType: 'IP',
-              // scopeDownStatement: {
-              //   byteMatchStatement: {
-              //     searchString: '/api/',
-              //     fieldToMatch: {
-              //       singleHeader: {
-              //         name: ':path',
-              //       },
-              //     },
-              //     textTransformations: [
-              //       {
-              //         priority: 0,
-              //         type: 'URL_DECODE',
-              //       },
-              //     ],
-              //     positionalConstraint: 'STARTS_WITH',
-              //   },
-              // },
             },
           },
           visibilityConfig: {
             cloudWatchMetricsEnabled: true,
-            metricName: 'rate-limit',
+            metricName: 'MetricForWaf-RateLimit',
+            sampledRequestsEnabled: true,
+          },
+        },
+        {
+          // rate-limit requests
+          name: 'RateLimitApi',
+          priority: 2,
+          action: {
+            block: {},
+          },
+          statement: {
+            rateBasedStatement: {
+              limit: 500, // per 5 minutes
+              aggregateKeyType: 'IP',
+              scopeDownStatement: {
+                byteMatchStatement: {
+                  searchString: '/api/',
+                  fieldToMatch: {
+                    singleHeader: {
+                      name: ':path',
+                    },
+                  },
+                  textTransformations: [
+                    {
+                      priority: 0,
+                      type: 'URL_DECODE',
+                    },
+                  ],
+                  positionalConstraint: 'STARTS_WITH',
+                },
+              },
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'MetricForWaf-RateLimitApi',
+            sampledRequestsEnabled: true,
+          },
+        },
+        {
+          name: 'DenyRequestsForSqlFiles',
+          priority: 3,
+          action: {
+            block: {},
+          },
+          statement: {
+            byteMatchStatement: {
+              // if request ends in .sql
+              searchString: '.sql',
+              fieldToMatch: {
+                singleHeader: {
+                  name: ':path',
+                },
+              },
+              positionalConstraint: 'ENDS_WITH',
+              textTransformations: [
+                {
+                  priority: 0,
+                  type: 'URL_DECODE',
+                },
+              ],
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'MetricForWaf-DenyRequestsForSqlFiles',
+            sampledRequestsEnabled: true,
+          },
+        },
+        {
+          name: 'DenyRequestsToWpAdmin',
+          priority: 4,
+          action: {
+            block: {},
+          },
+          statement: {
+            byteMatchStatement: {
+              // if requested path is wp-admin
+              searchString: '/wp-admin',
+              fieldToMatch: {
+                singleHeader: {
+                  name: ':path',
+                },
+              },
+              positionalConstraint: 'CONTAINS',
+              textTransformations: [
+                {
+                  priority: 0,
+                  type: 'URL_DECODE',
+                },
+              ],
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'MetricForWaf-DenyRequestsToWpAdmin',
+            sampledRequestsEnabled: true,
+          },
+        },
+        {
+          name: 'DenyRequestsToWpContent',
+          priority: 5,
+          action: {
+            block: {},
+          },
+          statement: {
+            byteMatchStatement: {
+              // if requested path is wp-content
+              searchString: '/wp-content',
+              fieldToMatch: {
+                singleHeader: {
+                  name: ':path',
+                },
+              },
+              positionalConstraint: 'CONTAINS',
+              textTransformations: [
+                {
+                  priority: 0,
+                  type: 'URL_DECODE',
+                },
+              ],
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'MetricForWaf-DenyRequestsToWpContent',
+            sampledRequestsEnabled: true,
+          },
+        },
+        {
+          name: 'DenyRequestsForSwagger',
+          priority: 6,
+          action: {
+            block: {},
+          },
+          statement: {
+            byteMatchStatement: {
+              // if requested path is swagger
+              searchString: '/swagger',
+              fieldToMatch: {
+                singleHeader: {
+                  name: ':path',
+                },
+              },
+              positionalConstraint: 'CONTAINS',
+              textTransformations: [
+                {
+                  priority: 0,
+                  type: 'URL_DECODE',
+                },
+              ],
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'MetricForWaf-DenyRequestsForSwagger',
             sampledRequestsEnabled: true,
           },
         },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Reduces RateLimit request limit from 1000 (per 5 minutes) to 500
- Adds RateLimitApi rule
- Adds rules to block the following requests:
	- requests ending in `.sql`
	- requests to `/wp-admin`
	- requests to `/wp-content`
	- requests to `/swagger`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
