### PR TITLE
cache pnpm manually in order to use corepack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,13 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           persist-credentials: false
       - uses: actions/setup-node@v3
+        id: setup-node
         with:
           node-version-file: '.node-version'
-          cache: 'pnpm'
+      - uses: actions/cache@v3
+        with:
+          path: '~/.pnpm-store'
+          key: ${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}
       - run: corepack enable
       - run: pnpm install
       - run: pnpm run lint


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`@actions/setup-node` does not support corepack out-of-the-box

With the move to use `corepack` and lean on `package.json#packageManager` to resolve package manager versions, the provided caching from `@actions/setup-node` cannot find the pnpm executable.

This PR aims to cache pnpm's store manually.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
