### PR TITLE
fix ignore pattern for pnpm deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,14 +2,8 @@
 node_modules
 *.log
 
-.env
-.env.*
+.env*
 !.env.sample
-cypress.env.json
-
-notes.md
-
-/prisma/data
-/build
 
 packages/**/build
+apps/**/build

--- a/apps/discord-bot-frontend/.gitignore
+++ b/apps/discord-bot-frontend/.gitignore
@@ -1,6 +1,6 @@
 # ignore SvelteKit output
 /.svelte-kit
-/build
+# /build
 # ignore test state files
 /playwright/*
 # ignore test report files


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

fixes issue with docker build where `pnpm deploy` the build output of the app. this is because pnpm looks at the localized gitignore as a filter when copying to the target destination (i.e. `./out`)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
