### PR TITLE
fix: permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
             return context.payload.pull_request.title.replace(/release\: /, '');
   prerelease:
     needs: verify-run
+    permissions:
+      id-token: write
+      contents: write
     uses: ./.github/workflows/release-env.yml
     secrets: inherit
     with:
@@ -38,6 +41,9 @@ jobs:
   release:
     needs: [verify-run, prerelease]
     if: ${{ fromJSON(needs.verify-run.outputs.is-prerelease) == false }}
+    permissions:
+      id-token: write
+      contents: write
     uses: ./.github/workflows/release-env.yml
     secrets: inherit
     with:


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

The `release` workflow was failing with `startup_failure` because the `prerelease` and `release` jobs call the reusable `release-env.yml` workflow, which requests `contents: write` and `id-token: write` permissions. Without explicit permissions on the calling jobs, they inherit the restrictive defaults from the `pull_request` trigger (`contents: read, id-token: none`), causing GitHub to reject the workflow before any job runs.

Added `permissions: id-token: write, contents: write` to both the `prerelease` and `release` jobs in `release.yml`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
