### PR TITLE
Scope admin configuration changes to the target configuration

### DIFF
--- a/apps/discord-bot-frontend/src/lib/server/require-configuration-admin.ts
+++ b/apps/discord-bot-frontend/src/lib/server/require-configuration-admin.ts
@@ -1,0 +1,20 @@
+import { getUserAccess } from '$lib/discord/get-user-access'
+
+/**
+ * Returns whether the given Discord user administers the specified configuration.
+ * A configuration's id is the Discord guild id, so access is resolved directly
+ * from the configuration id.
+ */
+export async function isConfigurationAdmin(
+  discordUserId: string | undefined,
+  configurationId: string | undefined
+): Promise<boolean> {
+  if (!discordUserId || !configurationId) return false
+  try {
+    const access = await getUserAccess(discordUserId, configurationId)
+    return access.isAdmin
+  } catch {
+    // no access when the membership lookup fails
+    return false
+  }
+}

--- a/apps/discord-bot-frontend/src/routes/api/admin/configure/+server.ts
+++ b/apps/discord-bot-frontend/src/routes/api/admin/configure/+server.ts
@@ -2,10 +2,22 @@ import type { RequestHandler } from '@sveltejs/kit'
 import { json } from '@sveltejs/kit'
 import { prisma } from '$lib/db'
 import { ACCESS_LEVELS } from '$lib/constants'
+import { isConfigurationAdmin } from '$lib/server/require-configuration-admin'
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, locals }) => {
   const { id, name, adminRoles, staffRoles, contributorRoles } =
     await request.json()
+
+  // Ensure the caller administers the target configuration. Creating a new
+  // configuration remains available to a guild owner (getUserAccess falls back
+  // to owner status when no configuration exists yet).
+  if (!locals.session?.user) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+  if (!(await isConfigurationAdmin(locals.session.user.discordUserId, id))) {
+    return new Response('Forbidden', { status: 403 })
+  }
+
   const record = await prisma.configuration.findUnique({
     where: { id },
     include: {
@@ -115,8 +127,17 @@ export const POST: RequestHandler = async ({ request }) => {
   }
 }
 
-export const DELETE: RequestHandler = async ({ request }) => {
+export const DELETE: RequestHandler = async ({ request, locals }) => {
   const { id } = await request.json()
+
+  // Ensure the caller administers the target configuration.
+  if (!locals.session?.user) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+  if (!(await isConfigurationAdmin(locals.session.user.discordUserId, id))) {
+    return new Response('Forbidden', { status: 403 })
+  }
+
   return json(
     await prisma.configuration.delete({
       where: { id },

--- a/apps/discord-bot-frontend/src/routes/api/admin/feature/+server.ts
+++ b/apps/discord-bot-frontend/src/routes/api/admin/feature/+server.ts
@@ -1,6 +1,7 @@
 import type { FEATURE_CODES } from '$lib/constants'
 import { type RequestHandler } from '@sveltejs/kit'
 import { prisma } from '$lib/db'
+import { isConfigurationAdmin } from '$lib/server/require-configuration-admin'
 
 type Payload = {
   /**
@@ -17,7 +18,7 @@ type Payload = {
   enabled: boolean
 }
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, locals }) => {
   let body: Payload
   try {
     /**
@@ -39,6 +40,19 @@ export const POST: RequestHandler = async ({ request }) => {
   const { configurationId, code, enabled } = body
   if (!configurationId || !code || enabled === undefined) {
     return new Response('Invalid request', { status: 400 })
+  }
+
+  // Ensure the caller administers the target configuration.
+  if (!locals.session?.user) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+  if (
+    !(await isConfigurationAdmin(
+      locals.session.user.discordUserId,
+      configurationId
+    ))
+  ) {
+    return new Response('Forbidden', { status: 403 })
   }
 
   try {


### PR DESCRIPTION
## Summary

Several `/api/admin` endpoints act on a configuration identified by an id in the
request body (`configurationId` / `id`), but they do not re-evaluate the caller's
access against that configuration. Access (`isAdmin`) is derived from the caller's
active guild (session), which may differ from the configuration being changed. This
is inconsistent with how access is determined elsewhere in the app and means these
endpoints can operate on a configuration other than the one the caller's access was
evaluated for.

This change evaluates the caller's access against the configuration each endpoint
actually modifies, using the existing `getUserAccess` helper (the same one the
session callback uses). Because a configuration's id is the guild id, access can be
resolved directly from the id in the request.

## Changes

- Add `src/lib/server/require-configuration-admin.ts` exporting
  `isConfigurationAdmin(discordUserId, configurationId)`, which resolves access for
  the target configuration and returns whether the caller is an admin. Non-members
  of the target guild resolve to `false`.
- `POST /api/admin/feature`: require an authenticated session and admin access for
  `configurationId` before updating features (`401` when unauthenticated, `403`
  when the caller does not administer the target configuration).
- `POST /api/admin/configure`: require the same before creating/updating a
  configuration and its role mappings. Onboarding is preserved — `getUserAccess`
  falls back to guild-owner status when no configuration exists yet, so a guild
  owner can still create their configuration.
- `DELETE /api/admin/configure`: require the same before deleting a configuration.

No changes to `POST/PUT/DELETE /api/admin/commands` or `GET /api/admin/is`: these
operate on the caller's active guild (`locals.guildId`) or are read-only, so the
object acted on already matches the guild access was evaluated for.

## Testing

- [ ] Manual: as an admin of guild A, changing A succeeds; changing another guild's
      configuration returns `403`; unauthenticated requests return `401`.
- [ ] Automated authorization coverage for these endpoints to follow.

> Draft — opening for early review while validation is completed.
